### PR TITLE
Add Urbie Green to trombone timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -2300,6 +2300,17 @@
     "websiteUrl": null
   },
   {
+    "id": "urbie-green",
+    "name": "U. Green",
+    "born": 1926,
+    "died": 2018,
+    "role": "player",
+    "bio": "American jazz trombonist celebrated for his warm, lyrical tone and effortless technique across an unusually wide range. He rose to prominence with the big bands of Woody Herman and Gene Krupa, appeared on hundreds of recordings alongside artists such as Count Basie and Tony Bennett, and was inducted into the Alabama Jazz Hall of Fame in 1995.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Urbie_Green",
+    "websiteUrl": null
+  },
+  {
     "id": "mangelsdorff",
     "name": "A. Mangelsdorff",
     "born": 1928,

--- a/public/data/trombone.json
+++ b/public/data/trombone.json
@@ -65,6 +65,7 @@
     "jj-johnson",
     "berio",
     "rosolino",
+    "urbie-green",
     "mangelsdorff",
     "denis-wick",
     "curtis-fuller",


### PR DESCRIPTION
## Summary

- Added jazz trombonist **Urbie Green** (1926–2018) as a new `player` in `public/data/people.json`.
- Registered `urbie-green` in the `trombone.json` timeline, placed among the 1926 Jazz Age cohort (right after Frank Rosolino).
- `photoUrl` is `null`: Urbie Green's Wikipedia article has no free-licensed lead image, so no portrait could be fetched (same sanctioned state as `curtis-fuller`/`watrous`). `download-portraits.mjs` is therefore unchanged.

Requested via the new-person form in #33.

Closes #33

## Test plan

- [x] `npm run build` (tsc + vite) — passes
- [x] Data integrity — both JSON files parse; `urbie-green` present in `people.json` and `trombone.json`; all 49 trombone `peopleIds` resolve; no duplicate IDs
- [x] `npm run lint` / `npm test` — no new problems introduced (3 lint errors + 1 `App.test.tsx` footer test failure are **pre-existing on `main`** and unrelated to this data-only change)