### PR TITLE
Add Vic Dickenson to trombone timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -2322,6 +2322,17 @@
     "websiteUrl": null
   },
   {
+    "id": "vic-dickenson",
+    "name": "V. Dickenson",
+    "born": 1906,
+    "died": 1984,
+    "role": "player",
+    "bio": "American jazz trombonist whose career ran from the 1920s into the 1980s, known for the wit and vocalized, smearing phrasing of his swing and traditional-jazz playing. He recorded and toured with Count Basie, Sidney Bechet, and Earl Hines, and led the acclaimed Vic Dickenson Septet sessions for Vanguard in 1953-54.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Vic_Dickenson",
+    "websiteUrl": null
+  },
+  {
     "id": "kai-winding",
     "name": "K. Winding",
     "born": 1922,

--- a/public/data/trombone.json
+++ b/public/data/trombone.json
@@ -61,6 +61,7 @@
     "teagarden",
     "tommy-dorsey",
     "creston",
+    "vic-dickenson",
     "kai-winding",
     "jj-johnson",
     "berio",

--- a/scripts/download-portraits.mjs
+++ b/scripts/download-portraits.mjs
@@ -68,6 +68,7 @@ const WIKIPEDIA_TITLES = {
   'glenn-miller': 'Glenn_Miller',
   'teagarden': 'Jack_Teagarden',
   'tommy-dorsey': 'Tommy_Dorsey',
+  'vic-dickenson': 'Vic_Dickenson',
   'kai-winding': 'Kai_Winding',
   'jj-johnson': 'J._J._Johnson',
   'berio': 'Luciano_Berio',


### PR DESCRIPTION
## Summary

- Add jazz trombonist **Vic Dickenson** (1906–1984, `player`) to the trombone timeline, inserted in birth-year order between `creston` and `kai-winding`.
- `people.json`: new `vic-dickenson` Person with a 2-sentence bio and `wikiUrl`. Wikipedia has no free lead image, so `photoUrl` is `null` (same as 40 existing people, e.g. `urbie-green`, `curtis-fuller`).
- `trombone.json`: add `vic-dickenson` to `peopleIds`.
- `download-portraits.mjs`: add the `WIKIPEDIA_TITLES` mapping so a portrait can be fetched later if a free image becomes available (the script skips null-`photoUrl` people, matching `curtis-fuller`).

Closes #60

## Test plan

- [x] `npm test` — 68 passing (includes the data-integrity Zod + referential-integrity checks)
- [x] `npm run lint` — clean
- [x] `npm run build` — TypeScript check + Vite build succeed