### PR TITLE
Add Eugène Bozza to trombone timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -2311,6 +2311,17 @@
     "websiteUrl": null
   },
   {
+    "id": "bozza",
+    "name": "E. Bozza",
+    "born": 1905,
+    "died": 1991,
+    "role": "composer",
+    "bio": "French composer and conductor who won the Premier Grand Prix de Rome in 1934 and became one of the most prolific creators of chamber music for wind instruments in the 20th century. His Ballade for trombone and piano and other solo works remain staples of the recital repertoire, prized for their lyrical melodies and idiomatic writing.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Eug%C3%A8ne_Bozza",
+    "websiteUrl": null
+  },
+  {
     "id": "creston",
     "name": "P. Creston",
     "born": 1906,

--- a/public/data/trombone.json
+++ b/public/data/trombone.json
@@ -60,6 +60,7 @@
     "glenn-miller",
     "teagarden",
     "tommy-dorsey",
+    "bozza",
     "creston",
     "kai-winding",
     "jj-johnson",


### PR DESCRIPTION
## Summary

- Add composer **Eugène Bozza** (1905–1991, French) to the trombone timeline, per the issue's request.
- New `Person` in `people.json` (id `bozza`, role `composer`, born 1905, died 1991) and `bozza` added to `trombone.json` `peopleIds`, placed in birth-year order between `tommy-dorsey` (1905) and `creston` (1906).
- `photoUrl` is `null`: no free portrait of Bozza exists on Wikipedia/Wikidata/Commons (he died in 1991, so photos remain under copyright). This mirrors the existing `creston` entry, so the `download-portraits.mjs` map is left unchanged.

Closes #59

## Test plan

- [x] `npx vitest run src/data-integrity.test.ts` — 14 passing (peopleIds refs valid, no dup ids)
- [x] `npm test` — 68 passing across 17 files
- [x] `npm run build` — tsc + Vite production build clean
- [x] `npx prettier --check` on the changed data files — clean