### PR TITLE
Add impeccable design context (PRODUCT.md, DESIGN.md, AGENTS.md)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,9 @@ dist-ssr
 coverage
 *.local
 
+# impeccable live-mode runtime journal (local recovery state, not source)
+.impeccable/live/sessions/
+
 # Editor directories and files
 .vscode/*
 !.vscode/extensions.json

--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -1,0 +1,246 @@
+{
+  "schemaVersion": 2,
+  "generatedAt": "2026-07-17",
+  "title": "Design System: Music Timeline",
+  "extensions": {
+    "colorMeta": {
+      "accent": {
+        "role": "primary",
+        "displayName": "Slate Blue",
+        "canonical": "#3d5a80",
+        "tonalRamp": [
+          "#0f172a",
+          "#1e293b",
+          "#2c4160",
+          "#3d5a80",
+          "#5b78a0",
+          "#8299bd",
+          "#b3c2d8",
+          "#dde5ef"
+        ]
+      },
+      "bg": {
+        "role": "neutral",
+        "displayName": "Paper",
+        "canonical": "#faf9f7",
+        "tonalRamp": [
+          "#3a3835",
+          "#57544f",
+          "#7a766f",
+          "#a09b92",
+          "#c4bfb6",
+          "#ddd8ce",
+          "#efece5",
+          "#faf9f7"
+        ]
+      },
+      "ink": {
+        "role": "neutral",
+        "displayName": "Ink",
+        "canonical": "#1a1a1a",
+        "tonalRamp": [
+          "#000000",
+          "#1a1a1a",
+          "#333333",
+          "#4d4d4d",
+          "#666666",
+          "#888888",
+          "#b3b3b3",
+          "#e0e0e0"
+        ]
+      },
+      "role-composer": {
+        "role": "tertiary",
+        "displayName": "Composer Blue",
+        "canonical": "#4a90d9",
+        "tonalRamp": [
+          "#0c2540",
+          "#143a63",
+          "#1f568f",
+          "#2e73b8",
+          "#4a90d9",
+          "#79aee4",
+          "#a9cbee",
+          "#d6e6f7"
+        ]
+      },
+      "role-player": {
+        "role": "tertiary",
+        "displayName": "Player Orange",
+        "canonical": "#e67e22",
+        "tonalRamp": [
+          "#4a2705",
+          "#6e3a08",
+          "#99530c",
+          "#c26a12",
+          "#e67e22",
+          "#ec9b52",
+          "#f2bd8c",
+          "#f8ddc4"
+        ]
+      },
+      "role-both": {
+        "role": "tertiary",
+        "displayName": "Both Purple",
+        "canonical": "#8e44ad",
+        "tonalRamp": [
+          "#2c1436",
+          "#431f52",
+          "#5e2c73",
+          "#7a3894",
+          "#8e44ad",
+          "#a969c1",
+          "#c496d6",
+          "#e0c7ea"
+        ]
+      }
+    },
+    "typographyMeta": {
+      "display": {
+        "displayName": "Display",
+        "purpose": "App/instrument title in the header. Cormorant Garamond serif."
+      },
+      "title": {
+        "displayName": "Title",
+        "purpose": "A person's name in the detail panel and tooltip. Cormorant Garamond serif."
+      },
+      "body": {
+        "displayName": "Body",
+        "purpose": "Bios and prose. Karla, capped 65-75ch."
+      },
+      "label": {
+        "displayName": "Label",
+        "purpose": "Role badge and section labels. Karla uppercase, 0.06em tracking. The only sanctioned tracked-uppercase text."
+      }
+    },
+    "shadows": [
+      {
+        "name": "panel-float",
+        "value": "-4px 0 24px rgba(0,0,0,0.08)",
+        "purpose": "Right-edge slide-in person panel, lifting it off the content beneath."
+      },
+      {
+        "name": "tooltip-float",
+        "value": "0 2px 12px rgba(0,0,0,0.12)",
+        "purpose": "Hover tooltip, a small card tracking the cursor."
+      }
+    ],
+    "motion": [
+      {
+        "name": "quick",
+        "value": "0.15s",
+        "purpose": "Hover color/border transitions on controls (selector border, close button)."
+      },
+      {
+        "name": "panel-slide",
+        "value": "transform 0.3s ease",
+        "purpose": "Person panel slide-in from the right. Needs a reduced-motion alternative."
+      }
+    ],
+    "breakpoints": [
+      { "name": "orientation-pivot", "value": "(min-aspect-ratio: 1/1)" }
+    ]
+  },
+  "components": [
+    {
+      "name": "Instrument Selector",
+      "kind": "input",
+      "refersTo": "instrument-select",
+      "description": "Native select that switches the active instrument; quiet warm-bordered control.",
+      "html": "<select class=\"ds-select\"><option>Piano</option><option>Violin</option><option>Trombone</option></select>",
+      "css": ".ds-select { font-family: Karla, sans-serif; font-size: 0.85rem; font-weight: 500; color: #1a1a1a; background: #ffffff; border: 1px solid #e0ddd8; border-radius: 6px; padding: 6px 14px; cursor: pointer; transition: border-color 0.15s; } .ds-select:hover { border-color: #3d5a80; } .ds-select:focus-visible { outline: 2px solid #3d5a80; outline-offset: 2px; }"
+    },
+    {
+      "name": "Role Badge",
+      "kind": "chip",
+      "refersTo": "role-chip",
+      "description": "Spelled-out role that backs up the lifetime bar's color encoding.",
+      "html": "<span class=\"ds-chip\">Composer</span>",
+      "css": ".ds-chip { display: inline-block; font-family: Karla, sans-serif; font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #555555; background: #f0ede8; border-radius: 12px; padding: 2px 10px; }"
+    },
+    {
+      "name": "Tooltip",
+      "kind": "custom",
+      "refersTo": "tooltip",
+      "description": "Hover card that tracks the cursor; serif name over small sans years.",
+      "html": "<div class=\"ds-tooltip\"><strong>F. Chopin</strong><span>1810 &ndash; 1849</span></div>",
+      "css": ".ds-tooltip { display: inline-block; background: #ffffff; border-radius: 6px; box-shadow: 0 2px 12px rgba(0,0,0,0.12); padding: 8px 12px; font-family: Karla, sans-serif; font-size: 0.8rem; color: #888888; } .ds-tooltip strong { display: block; font-family: 'Cormorant Garamond', Georgia, serif; font-size: 0.92rem; font-weight: 600; color: #1a1a1a; }"
+    },
+    {
+      "name": "Header Nav Link",
+      "kind": "nav",
+      "refersTo": "header-link",
+      "description": "Quiet accent text link used for contribution/feedback actions in the header.",
+      "html": "<a class=\"ds-navlink\" href=\"#\">Suggest a person</a>",
+      "css": ".ds-navlink { font-family: Karla, sans-serif; font-size: 0.8rem; font-weight: 500; color: #3d5a80; text-decoration: none; } .ds-navlink:hover { text-decoration: underline; } .ds-navlink:focus-visible { outline: 2px solid #3d5a80; outline-offset: 2px; border-radius: 2px; }"
+    },
+    {
+      "name": "Person Panel (compact)",
+      "kind": "card",
+      "refersTo": "person-panel",
+      "description": "Slide-in detail rail: serif name, years, role badge, bio, links. Shown here as a static compact card.",
+      "html": "<div class=\"ds-panel\"><h2>Fr&eacute;d&eacute;ric Chopin</h2><p class=\"ds-panel-years\">1810 &ndash; 1849</p><span class=\"ds-panel-role\">Composer</span><p class=\"ds-panel-bio\">Polish composer and virtuoso pianist of the Romantic era, celebrated for his solo piano works.</p><a class=\"ds-panel-link\" href=\"#\">Wikipedia</a></div>",
+      "css": ".ds-panel { background: #ffffff; box-shadow: -4px 0 24px rgba(0,0,0,0.08); padding: 28px; max-width: 360px; font-family: Karla, sans-serif; } .ds-panel h2 { font-family: 'Cormorant Garamond', Georgia, serif; font-size: 1.5rem; font-weight: 700; line-height: 1.2; color: #1a1a1a; } .ds-panel-years { color: #888888; font-size: 0.88rem; margin-top: 2px; } .ds-panel-role { display: inline-block; margin: 8px 0; padding: 2px 10px; border-radius: 12px; background: #f0ede8; font-size: 0.72rem; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em; color: #555555; } .ds-panel-bio { line-height: 1.65; color: #555555; font-size: 0.92rem; margin: 16px 0; } .ds-panel-link { color: #3d5a80; text-decoration: none; font-weight: 500; font-size: 0.88rem; } .ds-panel-link:hover { text-decoration: underline; }"
+    }
+  ],
+  "narrative": {
+    "northStar": "The Illuminated Almanac",
+    "overview": "Music Timeline is a literate almanac of music history rendered as an interactive canvas. It reads like a well-set reference volume that happens to be alive: names set in a warm serif, a paper-toned surface, centuries of composers and performers laid across quiet colored bands you can read at a glance. The register is a product (the timeline serves exploration), but the identity is deliberately editorial: Cormorant Garamond carries the names, Karla carries everything functional, and the palette holds to a single slate-blue accent over warm off-white, with role and era color used as information, never decoration. Depth is nearly absent; the timeline is flat, and shadow appears only where something genuinely floats above the page.",
+    "keyCharacteristics": [
+      "Editorial serif for names/titles, humanist sans for everything else.",
+      "Warm off-white paper surface (#faf9f7), a single slate-blue accent (#3d5a80).",
+      "Color is information: role hues, era bands, connection lines each earn their place.",
+      "Flat by default; soft ambient shadow only on floating overlays.",
+      "Restrained, deferential controls that never compete with the timeline."
+    ],
+    "rules": [
+      {
+        "name": "The One Accent Rule",
+        "body": "Slate blue (#3d5a80) is for interaction only - links and actionable controls. It never fills a shape and never decorates. Keep it under ~10% of any screen.",
+        "section": "colors"
+      },
+      {
+        "name": "The Quiet Bands Rule",
+        "body": "Era colors live at 30% opacity behind the timeline. They orient the eye across centuries; they never touch text, controls, or foreground.",
+        "section": "colors"
+      },
+      {
+        "name": "The Color-Is-Information Rule",
+        "body": "Every non-neutral hue encodes data (role, relationship, era). No hue is chosen for flavor. If a color can't name what it means, it doesn't belong.",
+        "section": "colors"
+      },
+      {
+        "name": "The Serif-Is-For-People Rule",
+        "body": "Cormorant Garamond is reserved for names and titles - the human beings the timeline is about. Every functional element is set in Karla. Never set a UI label, button, or data in the display serif.",
+        "section": "typography"
+      },
+      {
+        "name": "The One Eyebrow Rule",
+        "body": "The uppercase tracked label exists once, as the role badge. Do not multiply it into per-section kickers; that is the generic-AI tell this system rejects.",
+        "section": "typography"
+      },
+      {
+        "name": "The Flat-Timeline Rule",
+        "body": "The timeline is flat. Shadow appears only on genuinely floating overlays (panel, tooltip) and never as decoration on bars, bands, chips, or controls. A shadow on a resting surface is a bug.",
+        "section": "elevation"
+      }
+    ],
+    "dos": [
+      "Do reserve Cormorant Garamond for names and titles; set every control, label, datum, and body line in Karla.",
+      "Do hold the slate-blue accent (#3d5a80) to links and interactive affordances, under ~10% of any screen.",
+      "Do render era bands at 30% opacity behind the timeline as orientation only.",
+      "Do back every hue-coded signal with a non-color cue - the spelled-out role badge in the panel, and solid-vs-dashed connection lines - so meaning survives color-blindness.",
+      "Do honor prefers-reduced-motion: replace the 0.3s panel slide and hover transitions with an instant or crossfade alternative.",
+      "Do keep surfaces flat; add shadow only to the floating panel and tooltip."
+    ],
+    "donts": [
+      "Don't turn this into a generic AI/SaaS dashboard - no card grids, no gradient accents, no tiny uppercase tracked eyebrow labels above sections.",
+      "Don't let it become a cluttered infographic - no busy, over-labeled, rainbow-coded chart junk competing with the timeline.",
+      "Don't add childish or gamified edutainment - no cartoon styling, badges, or confetti.",
+      "Don't drift corporate or sterile - warmth is carried by the paper surface (#faf9f7) and serif names; never flatten to cold enterprise gray.",
+      "Don't set UI labels, controls, or data in the display serif, and never multiply the uppercase role label into per-section kickers.",
+      "Don't rely on hue alone to distinguish composer/player/both or relative/teacher connections.",
+      "Don't put shadow on a resting surface (bars, bands, chips, controls); a shadow at rest is a bug."
+    ]
+  }
+}

--- a/.impeccable/live/config.json
+++ b/.impeccable/live/config.json
@@ -1,0 +1,6 @@
+{
+  "files": ["index.html"],
+  "insertBefore": "</body>",
+  "commentSyntax": "html",
+  "cspChecked": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,13 @@
+# AGENTS
+
+See `CLAUDE.md` for commands, architecture, and data-integrity rules — they apply to all agents working in this repo.
+
+## Design Context
+
+Before designing or changing any UI, read the design context captured by `$impeccable init`:
+
+- **`PRODUCT.md`** — strategic context. Register is **product** (the timeline is a tool that serves exploration). Primary users are curious music learners, contributors/researchers, and Rightkey funnel visitors. Personality is **scholarly & timeless**. Anti-references: generic AI/SaaS dashboards, cluttered infographics, childish/gamified edutainment, corporate/sterile UI.
+- **`DESIGN.md`** — visual system (tokens + six-section spec). North Star: **"The Illuminated Almanac."** Cormorant Garamond serif for names/titles only; Karla for everything functional. One slate-blue accent (`#3d5a80`) over warm off-white (`#faf9f7`); color is information, not decoration; flat by default with soft shadow only on floating overlays.
+- **`.impeccable/`** — `design.json` token sidecar and `live/config.json` for `$impeccable live` mode.
+
+Treat `DESIGN.md` as authoritative on visual decisions and `PRODUCT.md` on strategic/voice decisions.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -207,6 +207,7 @@ Controls are **refined and restrained** — precise, quiet, and deferential to t
 ### Lifetime Bar (signature component)
 
 - **Style:** an SVG `<rect>`, 4px radius, filled by role color, with the name in 11px white sans inset at the left.
+- **Contrast (known deviation):** 11px white on the composer (`#4a90d9`, 3.34:1) and player (`#e67e22`, 2.85:1) fills is below AA 4.5:1 — this mirrors the current code, not an endorsed pairing. An AA-safe treatment (darker role fills, or a text plate/outline behind the name) is owed here; because white fails composer/player while black fails the purple "both" fill (3.58:1), there is no single-color swap, so the remedy lands with the code follow-up.
 - **States:** default; **highlighted** = 2px `#333` stroke (selected/connected); **dimmed** = 0.3 opacity (de-emphasized when another person is selected). Cursor is a pointer throughout.
 
 ### Connection Line (signature component)
@@ -233,4 +234,5 @@ Controls are **refined and restrained** — precise, quiet, and deferential to t
 - **Don't** drift corporate or sterile — warmth is carried by the paper surface (`#faf9f7`) and serif names; never flatten to cold enterprise gray.
 - **Don't** set UI labels, controls, or data in the display serif, and never multiply the uppercase role label into per-section kickers.
 - **Don't** rely on hue alone to distinguish composer/player/both or relative/teacher connections.
+- **Don't** treat the 11px-white-on-role-fill bar labels as AA-compliant — white clears only the purple "both" fill; composer (3.34:1) and player (2.85:1) are sub-AA and owed a darker-fill or text-plate remedy in the code follow-up.
 - **Don't** put shadow on a resting surface (bars, bands, chips, controls); a shadow at rest is a bug.

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -108,7 +108,7 @@ A warm-neutral paper base carries near-black text and a single reserved slate-bl
 
 - **Ink** (`#1a1a1a`): primary text — names, headings, body at full strength.
 - **Muted Ink** (`#555555`): secondary text — bios, legend labels, chip text.
-- **Subtle Ink** (`#888888`): tertiary text — years, subtitles, footer, time-axis labels.
+- **Subtle Ink** (`#888888`): tertiary text — years, subtitles, footer, time-axis labels. **Below AA for normal-size text** (3.54:1 on panel white, 3.37:1 on paper); this mirrors the current code and is a known deviation from the AA commitment, not an endorsed pairing. For small text, darken toward Muted Ink (`#555555`, 7.46:1) or reserve `#888888` for large/non-essential labels; changing the `--color-ink-subtle` token itself is a code follow-up.
 - **Paper** (`#faf9f7`): the warm off-white body surface. The room the timeline lives in.
 - **Panel White** (`#ffffff`): raised surfaces — header, slide-in panel, tooltip, footer.
 - **Border** (`#e0ddd8`): warm hairline dividers and control outlines, tuned to the paper, never gray-cold.
@@ -142,6 +142,8 @@ Semi-transparent bands (Material-50 tints at 30% opacity) sit behind the timelin
 **The Quiet Bands Rule.** Era colors live at 30% opacity _behind_ the timeline. They orient the eye across centuries; they never touch text, controls, or foreground. If a band competes with a person bar for attention, the band is too strong.
 
 **The Color-Is-Information Rule.** Every non-neutral hue encodes data (role, relationship, era). No hue is chosen for flavor. If a color can't name what it means, it doesn't belong.
+
+**The AA-Contrast Rule.** Every text/background pairing meets WCAG 2.1 AA — 4.5:1 for normal-size text, 3:1 for large (≥18px, or bold ≥14px). Values inherited from the current code that fall short are flagged as known deviations pending a code follow-up, not endorsed patterns. The first is Subtle Ink `#888888` used as small text (see above).
 
 ## 3. Typography
 
@@ -220,6 +222,7 @@ Controls are **refined and restrained** — precise, quiet, and deferential to t
 - **Do** render era bands at 30% opacity behind the timeline as orientation only.
 - **Do** back every hue-coded signal with a non-color cue — the spelled-out role badge in the panel, and solid-vs-dashed connection lines — so meaning survives color-blindness.
 - **Do** honor `prefers-reduced-motion`: replace the 0.3s panel slide and hover transitions with an instant or crossfade alternative.
+- **Do** meet WCAG 2.1 AA contrast on text (4.5:1 normal, 3:1 large); the current Subtle-Ink small text is a flagged sub-AA deviation to remediate in code, not a pattern to copy.
 - **Do** keep surfaces flat; add shadow only to the floating panel and tooltip.
 
 ### Don't:

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,233 @@
+---
+name: Music Timeline
+description: An interactive, scholarly timeline of composers and performers across instruments.
+colors:
+  ink: '#1a1a1a'
+  ink-muted: '#555555'
+  ink-subtle: '#888888'
+  accent: '#3d5a80'
+  border: '#e0ddd8'
+  bg: '#faf9f7'
+  panel-bg: '#ffffff'
+  chip-bg: '#f0ede8'
+  role-composer: '#4a90d9'
+  role-player: '#e67e22'
+  role-both: '#8e44ad'
+  connection-relative: '#e74c3c'
+  connection-teacher: '#3498db'
+  era-baroque: '#e3f2fd'
+  era-classical: '#fff3e0'
+  era-romantic: '#fce4ec'
+  era-modern: '#e8f5e9'
+  era-contemporary: '#f3e5f5'
+  era-alt: '#fff9c4'
+typography:
+  display:
+    fontFamily: 'Cormorant Garamond, Georgia, serif'
+    fontSize: '1.65rem'
+    fontWeight: 700
+    lineHeight: 1.2
+    letterSpacing: '-0.01em'
+  title:
+    fontFamily: 'Cormorant Garamond, Georgia, serif'
+    fontSize: '1.5rem'
+    fontWeight: 700
+    lineHeight: 1.2
+  body:
+    fontFamily: 'Karla, Helvetica Neue, sans-serif'
+    fontSize: '0.92rem'
+    fontWeight: 400
+    lineHeight: 1.65
+  label:
+    fontFamily: 'Karla, Helvetica Neue, sans-serif'
+    fontSize: '0.72rem'
+    fontWeight: 600
+    lineHeight: 1.2
+    letterSpacing: '0.06em'
+rounded:
+  xs: '4px'
+  sm: '6px'
+  md: '8px'
+  pill: '12px'
+spacing:
+  xs: '4px'
+  sm: '8px'
+  md: '16px'
+  lg: '28px'
+components:
+  instrument-select:
+    backgroundColor: '{colors.panel-bg}'
+    textColor: '{colors.ink}'
+    rounded: '{rounded.sm}'
+    padding: '6px 14px'
+  role-chip:
+    backgroundColor: '{colors.chip-bg}'
+    textColor: '{colors.ink-muted}'
+    rounded: '{rounded.pill}'
+    padding: '2px 10px'
+  person-panel:
+    backgroundColor: '{colors.panel-bg}'
+    textColor: '{colors.ink}'
+    padding: '28px'
+  tooltip:
+    backgroundColor: '{colors.panel-bg}'
+    textColor: '{colors.ink}'
+    rounded: '{rounded.sm}'
+    padding: '8px 12px'
+---
+
+# Design System: Music Timeline
+
+## 1. Overview
+
+**Creative North Star: "The Illuminated Almanac"**
+
+Music Timeline is a literate almanac of music history rendered as an interactive canvas. It reads like a well-set reference volume that happens to be alive: names set in a warm serif, a paper-toned surface, centuries of composers and performers laid across quiet colored bands you can read at a glance. The system's job is to make history _explorable and trustworthy_ — nothing on screen should feel approximate, gimmicky, or louder than the people it describes.
+
+The register is a **product** (the timeline is a tool that serves exploration), but the identity is deliberately editorial. Cormorant Garamond carries the names because the names are the point; Karla carries everything functional so the interface stays legible and out of the way. The palette is restrained to a single slate-blue accent over a warm off-white, with role and era color used as _information_, never decoration. Depth is nearly absent — the timeline is flat, and shadow appears only where something genuinely floats above the page.
+
+This system explicitly rejects the generic AI/SaaS dashboard (card grids, gradient accents, tracked-uppercase eyebrow labels), the cluttered rainbow infographic, childish or gamified edutainment, and cold corporate sterility. Warmth comes from paper and serif, not from ornament.
+
+**Key Characteristics:**
+
+- Editorial serif for names/titles, humanist sans for everything else.
+- Warm off-white paper surface (`#faf9f7`), a single slate-blue accent (`#3d5a80`).
+- Color is information: role hues, era bands, connection lines — each earns its place.
+- Flat by default; soft ambient shadow only on floating overlays.
+- Restrained, deferential controls that never compete with the timeline.
+
+## 2. Colors
+
+A warm-neutral paper base carries near-black text and a single reserved slate-blue accent; every other hue is a data encoding, not styling.
+
+### Primary
+
+- **Slate Blue** (`#3d5a80`): the one interactive accent. Links, the instrument selector's hover border, in-panel connection links. Marks "you can act here" and nothing else.
+
+### Neutral
+
+- **Ink** (`#1a1a1a`): primary text — names, headings, body at full strength.
+- **Muted Ink** (`#555555`): secondary text — bios, legend labels, chip text.
+- **Subtle Ink** (`#888888`): tertiary text — years, subtitles, footer, time-axis labels.
+- **Paper** (`#faf9f7`): the warm off-white body surface. The room the timeline lives in.
+- **Panel White** (`#ffffff`): raised surfaces — header, slide-in panel, tooltip, footer.
+- **Border** (`#e0ddd8`): warm hairline dividers and control outlines, tuned to the paper, never gray-cold.
+- **Chip** (`#f0ede8`): the role badge's soft warm fill in the person panel.
+
+### Tertiary — Role Encoding
+
+Lifetime bars are colored by role. Hue is a _shortcut_, never the sole signal — the person panel always spells the role out in words.
+
+- **Composer Blue** (`#4a90d9`): role = composer.
+- **Player Orange** (`#e67e22`): role = player.
+- **Both Purple** (`#8e44ad`): role = both.
+
+### Tertiary — Connection Encoding
+
+Connection lines are distinguished by **line pattern first, color second**, so the relationship survives color-blindness.
+
+- **Relative Red** (`#e74c3c`): family ties — drawn solid.
+- **Teacher Blue** (`#3498db`): student/teacher links — drawn dashed (`6 3`).
+
+### Tertiary — Era Bands
+
+Semi-transparent bands (Material-50 tints at 30% opacity) sit behind the timeline as orientation. They blend where eras overlap.
+
+- **Baroque** (`#e3f2fd`), **Classical** (`#fff3e0`), **Romantic** (`#fce4ec`), **Modern** (`#e8f5e9`), **Contemporary** (`#f3e5f5`), plus an alternate tint (`#fff9c4`) for additional eras.
+
+### Named Rules
+
+**The One Accent Rule.** Slate blue (`#3d5a80`) is for interaction only — links and actionable controls. It never fills a shape and never decorates. Keep it under ~10% of any screen.
+
+**The Quiet Bands Rule.** Era colors live at 30% opacity _behind_ the timeline. They orient the eye across centuries; they never touch text, controls, or foreground. If a band competes with a person bar for attention, the band is too strong.
+
+**The Color-Is-Information Rule.** Every non-neutral hue encodes data (role, relationship, era). No hue is chosen for flavor. If a color can't name what it means, it doesn't belong.
+
+## 3. Typography
+
+**Display Font:** Cormorant Garamond (with Georgia, serif fallback)
+**Body Font:** Karla (with Helvetica Neue, sans-serif fallback)
+
+**Character:** A high-contrast pairing on the classic axis — a literary old-style serif against a clean humanist grotesque. The serif lends the names gravity and timelessness; the sans keeps the working interface crisp and quiet. The contrast is intentional and load-bearing: it is what makes an exploration tool feel like a reference book rather than a chart.
+
+### Hierarchy
+
+- **Display** (Cormorant Garamond, 700, 1.65rem, line-height 1.2, letter-spacing -0.01em): the app/instrument title in the header.
+- **Title** (Cormorant Garamond, 700, 1.5rem, line-height 1.2): a person's name in the detail panel and the tooltip.
+- **Body** (Karla, 400, 0.92rem, line-height 1.65): bios and prose. Cap prose at 65–75ch.
+- **Label** (Karla, 600, 0.72rem, letter-spacing 0.06em, uppercase): the role badge and section labels inside the panel. This is the _only_ sanctioned uppercase-tracked text — a labeled datum, never a decorative eyebrow above a section.
+
+### Named Rules
+
+**The Serif-Is-For-People Rule.** Cormorant Garamond is reserved for names and titles — the human beings the timeline is about. Every functional element (controls, labels, data, years, legends, body copy) is set in Karla. Never set a UI label, a button, or data in the display serif.
+
+**The One Eyebrow Rule.** The uppercase tracked label exists once, as the role badge. Do not multiply it into per-section kickers; that is the generic-AI tell this system rejects.
+
+## 4. Elevation
+
+The system is **flat by default**. The timeline canvas — era bands, lifetime bars, connection curves, axis — carries zero shadow; depth there is conveyed entirely by color, opacity, and overlap. Shadow is admitted only where an element genuinely floats above the page: the slide-in person panel and the hover tooltip. Both use a soft, low-opacity ambient shadow, never a hard or dark drop shadow.
+
+### Shadow Vocabulary
+
+- **Panel float** (`box-shadow: -4px 0 24px rgba(0,0,0,0.08)`): the right-edge slide-in person panel, lifting it off the content beneath.
+- **Tooltip float** (`box-shadow: 0 2px 12px rgba(0,0,0,0.12)`): the hover tooltip, a small card tracking the cursor.
+
+### Named Rules
+
+**The Flat-Timeline Rule.** The timeline is flat. Shadow appears only on genuinely floating overlays (panel, tooltip) and never as decoration on bars, bands, chips, or controls. A shadow on a resting surface is a bug.
+
+## 5. Components
+
+Controls are **refined and restrained** — precise, quiet, and deferential to the timeline. They read as the furniture of a reference book, not the chrome of an app.
+
+### Instrument Selector
+
+- **Style:** a native `<select>` with a 1px warm border (`#e0ddd8`), 6px radius, `6px 14px` padding, on panel white, set in Karla 500.
+- **Hover:** border shifts to slate-blue accent (`#3d5a80`); a 0.15s color transition, nothing else moves.
+- **Behavior:** a trailing "New Instrument…" option routes to the contribution form rather than selecting — the product visibly invites additions.
+
+### Role Badge (Chip)
+
+- **Style:** soft warm fill (`#f0ede8`), muted-ink text, 12px radius, `2px 10px` padding.
+- **Type:** Karla 600, 0.72rem, uppercase, 0.06em tracking — the spelled-out role that backs up the bar's color encoding.
+
+### Person Panel
+
+- **Corner / surface:** panel white, full-height fixed rail on the right (360px, max 90vw), 28px padding.
+- **Elevation:** panel-float shadow (see Elevation).
+- **Motion:** slides in via `transform: translateX` over 0.3s ease. Contains the portrait (8px radius), name in serif title, years in subtle ink, role badge, bio, external links (Wikipedia / website) in accent, and a connections list of accent text-buttons.
+- **Close:** a quiet ✕ in subtle ink that darkens to ink on hover.
+
+### Tooltip
+
+- **Style:** panel white, 6px radius, `8px 12px` padding, tooltip-float shadow. Name in serif (0.92rem, 600) over years in small sans. Tracks the cursor; appears on hover only.
+
+### Lifetime Bar (signature component)
+
+- **Style:** an SVG `<rect>`, 4px radius, filled by role color, with the name in 11px white sans inset at the left.
+- **States:** default; **highlighted** = 2px `#333` stroke (selected/connected); **dimmed** = 0.3 opacity (de-emphasized when another person is selected). Cursor is a pointer throughout.
+
+### Connection Line (signature component)
+
+- **Style:** an SVG bezier curve between two bars. **Relative** = solid red (`#e74c3c`); **student/teacher** = dashed blue (`#3498db`, dash `6 3`). Pattern carries the meaning; color reinforces it.
+
+## 6. Do's and Don'ts
+
+### Do:
+
+- **Do** reserve Cormorant Garamond for names and titles; set every control, label, datum, and body line in Karla.
+- **Do** hold the slate-blue accent (`#3d5a80`) to links and interactive affordances, under ~10% of any screen.
+- **Do** render era bands at 30% opacity behind the timeline as orientation only.
+- **Do** back every hue-coded signal with a non-color cue — the spelled-out role badge in the panel, and solid-vs-dashed connection lines — so meaning survives color-blindness.
+- **Do** honor `prefers-reduced-motion`: replace the 0.3s panel slide and hover transitions with an instant or crossfade alternative.
+- **Do** keep surfaces flat; add shadow only to the floating panel and tooltip.
+
+### Don't:
+
+- **Don't** turn this into a generic AI/SaaS dashboard — no card grids, no gradient accents, no tiny uppercase tracked eyebrow labels above sections.
+- **Don't** let it become a cluttered infographic — no busy, over-labeled, rainbow-coded chart junk competing with the timeline.
+- **Don't** add childish or gamified edutainment — no cartoon styling, badges, or confetti.
+- **Don't** drift corporate or sterile — warmth is carried by the paper surface (`#faf9f7`) and serif names; never flatten to cold enterprise gray.
+- **Don't** set UI labels, controls, or data in the display serif, and never multiply the uppercase role label into per-section kickers.
+- **Don't** rely on hue alone to distinguish composer/player/both or relative/teacher connections.
+- **Don't** put shadow on a resting surface (bars, bands, chips, controls); a shadow at rest is a bug.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -1,0 +1,47 @@
+# Product
+
+## Register
+
+product
+
+## Users
+
+Three overlapping audiences arrive at the timeline, mostly through casual, self-directed browsing on desktop and mobile (landscape and portrait), often in a single curious session rather than repeat task-work.
+
+- **Curious music learners** — piano and music students exploring who came before them, how composers and performers connect (teacher/student, family, influence), and where they sit across eras. This is the primary audience; the experience is tuned for their curiosity.
+- **Rightkey funnel visitors** — people arriving via Rightkey.app marketing, meant to be delighted enough to explore and then click through to the learning app.
+- **Contributors & researchers** — people who add or correct people, connections, and instruments, growing and sharpening the dataset over time.
+
+## Product Purpose
+
+An interactive timeline of composers and performers across instruments. It lets anyone explore who shaped music history, how those figures are connected, and where they sit across the eras — by hovering, opening a person's detail panel, following connections, and switching instruments.
+
+It exists to make music history genuinely explorable and delightful, to stand as a growing and trusted reference, and — built in collaboration with Rightkey.app — to draw curious learners toward learning to play.
+
+Success looks like: visitors who explore deeply rather than glance and leave; a dataset trusted for its accuracy and breadth; and a community that keeps it growing through submissions and corrections.
+
+## Brand Personality
+
+Scholarly and timeless — refined, curious, trustworthy. The voice is that of a well-made reference book: calm, literate, and quietly confident, never shouting for attention. The interface should evoke the pleasure of discovery and the reassurance of accuracy. Emotional goals: curiosity, calm, trust.
+
+## Anti-references
+
+- **Generic AI/SaaS dashboards** — card grids, gradient accents, tiny tracked eyebrow labels, the default-tool template.
+- **Cluttered infographics** — busy, over-labeled, rainbow-coded chart junk that buries the timeline instead of revealing it.
+- **Childish or gamified edutainment** — cartoon styling, badges, confetti; anything that undercuts credibility.
+- **Corporate / sterile enterprise UI** — cold, faceless, characterless surfaces with no warmth.
+
+## Design Principles
+
+- **The history is the hero.** The interface recedes so the people, eras, and connections carry the experience. Nothing decorative should compete with the data.
+- **Reward exploration.** Every element invites the next discovery — a hover, a panel, a connection to follow, an instrument to switch to — with as little friction as possible. Curiosity is the engine; keep it flowing.
+- **Earn trust through accuracy and legibility.** As a reference, correctness, clear sourcing, and unambiguous reading matter more than flourish. Nothing should feel approximate or decorative-over-truthful.
+- **Lower the contribution barrier.** The product should read as an open, growing artifact that visibly welcomes additions and corrections — not a closed, finished object.
+- **Timeless over trendy.** Choices should still read well in ten years. This is a historical reference, not a product chasing current UI fashion.
+
+## Accessibility & Inclusion
+
+- Target **WCAG 2.1 AA** for contrast and conformance across text, controls, and the SVG timeline.
+- **Full keyboard navigation and screen-reader support:** person bars, connections, and the slide-in detail panel must be reachable and understandable via assistive technology.
+- **Colorblind-safe encoding:** role colors (composer / player / both) and connection types (relative / student-teacher) must not rely on hue alone — pair with shape, pattern, position, or label.
+- **Honor `prefers-reduced-motion`** for panel slides, hover transitions, and any timeline animation, with a crossfade or instant alternative.


### PR DESCRIPTION
Captures strategic and visual design context for the project via `$impeccable init`, so future UI work (and agents) stay on-brand.

## What's added
- **`PRODUCT.md`** — strategic context. Register is **product** (the timeline is a tool that serves exploration). Users: curious music learners, contributors/researchers, Rightkey funnel visitors. Personality: **scholarly & timeless**. Records anti-references, 5 design principles, and accessibility commitments (WCAG 2.1 AA, keyboard + SR support, colorblind-safe roles, reduced motion).
- **`DESIGN.md`** — visual system in the DESIGN.md spec format: token frontmatter + six prose sections. North Star: **"The Illuminated Almanac."** Documents the deliberate Cormorant Garamond (names) / Karla (everything functional) pairing, the single slate-blue accent over warm off-white, color-as-information, and flat-by-default elevation.
- **`.impeccable/design.json`** — token sidecar (tonal ramps, shadow/motion tokens, renderable component snippets, narrative).
- **`.impeccable/live/config.json`** — config for `$impeccable live` in-browser variant mode (Vite SPA).
- **`AGENTS.md`** — short Design Context pointer to the above.
- **`.gitignore`** — ignore the live-mode session journal (`.impeccable/live/sessions/`).

## Notes
- Docs and config only — no application code or runtime behavior changes.
- New Markdown/JSON files pass the repo's Prettier gate.
- `DESIGN.md` is authoritative on visual decisions; `PRODUCT.md` on strategic/voice decisions.

## Suggested follow-ups (not in this PR)
The recorded accessibility bar is aspirational; the current code misses it in concrete ways worth a follow-up: SVG lifetime bars have no keyboard path, the person-panel slide transition lacks a `prefers-reduced-motion` guard, and role is hue-only on the timeline.