### PR TITLE
Document optional Person.fullName field in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,8 @@ The `useInstrumentData` hook fetches all three, caches people/connections in a `
 
 To add a new instrument: create `public/data/<name>.json` with eras and peopleIds, add new people to `people.json` if needed, and add `'<name>'` to the `INSTRUMENTS` array in `App.tsx`.
 
+Each `Person` has a required `name` — the compact label shown on the timeline bar (first-initial + surname, e.g. `J. Bologne`) — and an optional `fullName` for the detail panel and tooltip (e.g. `Joseph Bologne, Chevalier de Saint-Georges`). Set `fullName` only when the short label hides a widely-known full name; `PersonPanel` and `Tooltip` render `fullName ?? name`, while the width-constrained `PersonBar` always uses `name`.
+
 ### Rendering Pipeline
 
 `App` → `TimelineView` (scrollable container with zoom) → `TimelineSVG` (the SVG):


### PR DESCRIPTION
## Summary

- Follow-up to #83: document the `Person.fullName` field in `CLAUDE.md` so the convention is discoverable where contributors look, not only in the type definition.
- Notes the split: required `name` is the compact bar label (initial + surname), optional `fullName` is the full name shown in the detail panel and tooltip via `fullName ?? name`, and `PersonBar` always uses the short `name`.

Docs-only; no code or behavior change.

## Test plan

- [x] `npm run format:check` — clean (only the local `.claude/settings.local.json` warns, unrelated)