### PR TITLE
ci: enforce Conventional Commits (PR titles + commitlint)

### DIFF
--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - uses: actions/setup-node@v7.0.0
         with:
           node-version: lts/*

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,26 @@
+# Lints commit messages against Conventional Commits on pushes to the default branch.
+# Direct pushes are what the PR-title check can't see; PRs are covered by lint-pr-title.yml.
+name: Lint commits
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  commitlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7.0.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v7.0.0
+        with:
+          node-version: lts/*
+      - name: Install commitlint
+        run: npm install --no-save @commitlint/cli@21 @commitlint/config-conventional@21
+      - name: Lint pushed commits
+        if: github.event.before != '0000000000000000000000000000000000000000'
+        run: npx commitlint --from ${{ github.event.before }} --to ${{ github.sha }} --verbose

--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,23 @@
+# Enforces that PR titles follow the Conventional Commits spec.
+# https://www.conventionalcommits.org/  |  https://github.com/amannn/action-semantic-pull-request
+name: Lint PR title
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+
+permissions:
+  pull-requests: read
+
+jobs:
+  validate:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -6,3 +6,16 @@ rules:
     config:
       policies:
         '*': ref-pin
+  # lint-pr-title.yml intentionally uses pull_request_target so a malicious PR
+  # can't disable its own title check by editing the workflow file. It never
+  # checks out PR code and only has pull-requests: read — the canonical safe
+  # use of this trigger.
+  dangerous-triggers:
+    ignore:
+      - lint-pr-title.yml
+  # commitlint.yml installs commitlint ad hoc rather than via the app's
+  # package-lock.json: it's a CI-only lint tool, unrelated to the app's
+  # runtime/build dependency graph.
+  adhoc-packages:
+    ignore:
+      - commitlint.yml

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -1,0 +1,5 @@
+/* Conventional Commits ruleset for commitlint.
+ * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
+module.exports = {
+  extends: ['@commitlint/config-conventional'],
+};

--- a/commitlint.config.cjs
+++ b/commitlint.config.cjs
@@ -2,4 +2,13 @@
  * .cjs so it loads correctly whether or not the repo's package.json sets "type":"module". */
 module.exports = {
   extends: ['@commitlint/config-conventional'],
+  rules: {
+    // lint-pr-title.yml only checks type + optional scope (no subjectPattern
+    // configured), so keep this check structural-only too — otherwise a title
+    // that passes PR review can still fail here once GitHub's squash-merge
+    // appends " (#NN)" to the subject or capitalizes it naturally.
+    'subject-case': [0],
+    'subject-full-stop': [0],
+    'header-max-length': [0],
+  },
 };


### PR DESCRIPTION
Standardizes this repository on [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/).

### Adds
- `.github/workflows/lint-pr-title.yml` — validates **PR titles** with [`amannn/action-semantic-pull-request@v6`](https://github.com/amannn/action-semantic-pull-request).
- `.github/workflows/commitlint.yml` — lints **commit messages** on pushes to `main` (covers direct pushes the PR-title check can't see).
- `commitlint.config.cjs` — the Conventional Commits ruleset (`.cjs` so it loads under `"type":"module"` too).

### Notes
- For the PR-title check to feed clean history, enable **Settings → Pull Requests → Allow squash merging** with *"Default to PR title for squash-merge commits"*.
- `commitlint.yml` only lints commits going forward — it does not fail on existing history.

_Part of a cross-repo standardization pass. Review and merge, or close if unwanted._
