### PR TITLE
fix: deep AA-safe role palette, glyph markers, and viz-token consolidation

### DIFF
--- a/.impeccable/design.json
+++ b/.impeccable/design.json
@@ -51,47 +51,47 @@
       },
       "role-composer": {
         "role": "tertiary",
-        "displayName": "Composer Blue",
-        "canonical": "#4a90d9",
+        "displayName": "Deep Composer Blue",
+        "canonical": "#2f6690",
         "tonalRamp": [
-          "#0c2540",
-          "#143a63",
-          "#1f568f",
-          "#2e73b8",
-          "#4a90d9",
-          "#79aee4",
-          "#a9cbee",
-          "#d6e6f7"
+          "#152e41",
+          "#1f425e",
+          "#275476",
+          "#2f6690",
+          "#5985a6",
+          "#86a6bf",
+          "#b6c9d8",
+          "#e0e8ee"
         ]
       },
       "role-player": {
         "role": "tertiary",
-        "displayName": "Player Orange",
-        "canonical": "#e67e22",
+        "displayName": "Deep Player Ochre",
+        "canonical": "#8a5314",
         "tonalRamp": [
-          "#4a2705",
-          "#6e3a08",
-          "#99530c",
-          "#c26a12",
-          "#e67e22",
-          "#ec9b52",
-          "#f2bd8c",
-          "#f8ddc4"
+          "#3e2509",
+          "#5a360d",
+          "#714410",
+          "#8a5314",
+          "#a17543",
+          "#bb9b77",
+          "#d6c3ad",
+          "#ede5dc"
         ]
       },
       "role-both": {
         "role": "tertiary",
-        "displayName": "Both Purple",
-        "canonical": "#8e44ad",
+        "displayName": "Deep Both Plum",
+        "canonical": "#7a3f88",
         "tonalRamp": [
-          "#2c1436",
-          "#431f52",
-          "#5e2c73",
-          "#7a3894",
-          "#8e44ad",
-          "#a969c1",
-          "#c496d6",
-          "#e0c7ea"
+          "#371c3d",
+          "#4f2958",
+          "#643470",
+          "#7a3f88",
+          "#9565a0",
+          "#b290ba",
+          "#d0bcd5",
+          "#ebe2ed"
         ]
       }
     },
@@ -138,7 +138,10 @@
       }
     ],
     "breakpoints": [
-      { "name": "orientation-pivot", "value": "(min-aspect-ratio: 1/1)" }
+      {
+        "name": "orientation-pivot",
+        "value": "(min-aspect-ratio: 1/1)"
+      }
     ]
   },
   "components": [
@@ -223,6 +226,16 @@
         "name": "The Flat-Timeline Rule",
         "body": "The timeline is flat. Shadow appears only on genuinely floating overlays (panel, tooltip) and never as decoration on bars, bands, chips, or controls. A shadow on a resting surface is a bug.",
         "section": "elevation"
+      },
+      {
+        "name": "The Shape-Encodes-Role Rule",
+        "body": "Categorical meaning never rests on hue alone. Role carries a monochrome glyph (composer, player, both) alongside its color; connections carry a line pattern (solid vs dashed). The legend teaches both channels.",
+        "section": "colors"
+      },
+      {
+        "name": "The AA-Contrast Rule",
+        "body": "Every text/background pairing meets WCAG 2.1 AA. Role fills are deep enough that white 11px bar names clear AA; Subtle Ink is #6c6c6c; the time-axis line is #8c8c8c (3:1 non-text).",
+        "section": "colors"
       }
     ],
     "dos": [
@@ -231,7 +244,8 @@
       "Do render era bands at 30% opacity behind the timeline as orientation only.",
       "Do back every hue-coded signal with a non-color cue - the spelled-out role badge in the panel, and solid-vs-dashed connection lines - so meaning survives color-blindness.",
       "Do honor prefers-reduced-motion: replace the 0.3s panel slide and hover transitions with an instant or crossfade alternative.",
-      "Do keep surfaces flat; add shadow only to the floating panel and tooltip."
+      "Do keep surfaces flat; add shadow only to the floating panel and tooltip.",
+      "Do back every hue-coded signal with a non-color cue - the per-bar role glyph, solid-vs-dashed connection lines, and the spelled-out role in the panel."
     ],
     "donts": [
       "Don't turn this into a generic AI/SaaS dashboard - no card grids, no gradient accents, no tiny uppercase tracked eyebrow labels above sections.",
@@ -240,7 +254,8 @@
       "Don't drift corporate or sterile - warmth is carried by the paper surface (#faf9f7) and serif names; never flatten to cold enterprise gray.",
       "Don't set UI labels, controls, or data in the display serif, and never multiply the uppercase role label into per-section kickers.",
       "Don't rely on hue alone to distinguish composer/player/both or relative/teacher connections.",
-      "Don't put shadow on a resting surface (bars, bands, chips, controls); a shadow at rest is a bug."
+      "Don't put shadow on a resting surface (bars, bands, chips, controls); a shadow at rest is a bug.",
+      "Don't lighten the role fills back toward the old bright Material hues - the deep values are what let white bar names clear AA."
     ]
   }
 }

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -4,17 +4,17 @@ description: An interactive, scholarly timeline of composers and performers acro
 colors:
   ink: '#1a1a1a'
   ink-muted: '#555555'
-  ink-subtle: '#888888'
+  ink-subtle: '#6c6c6c'
   accent: '#3d5a80'
   border: '#e0ddd8'
   bg: '#faf9f7'
   panel-bg: '#ffffff'
   chip-bg: '#f0ede8'
-  role-composer: '#4a90d9'
-  role-player: '#e67e22'
-  role-both: '#8e44ad'
-  connection-relative: '#e74c3c'
-  connection-teacher: '#3498db'
+  role-composer: '#2f6690'
+  role-player: '#8a5314'
+  role-both: '#7a3f88'
+  connection-relative: '#c0392b'
+  connection-teacher: '#2980b9'
   era-baroque: '#e3f2fd'
   era-classical: '#fff3e0'
   era-romantic: '#fce4ec'
@@ -108,7 +108,7 @@ A warm-neutral paper base carries near-black text and a single reserved slate-bl
 
 - **Ink** (`#1a1a1a`): primary text — names, headings, body at full strength.
 - **Muted Ink** (`#555555`): secondary text — bios, legend labels, chip text.
-- **Subtle Ink** (`#888888`): tertiary text — years, subtitles, footer, time-axis labels. **Below AA for normal-size text** (3.54:1 on panel white, 3.37:1 on paper); this mirrors the current code and is a known deviation from the AA commitment, not an endorsed pairing. For small text, darken toward Muted Ink (`#555555`, 7.46:1) or reserve `#888888` for large/non-essential labels; changing the `--color-ink-subtle` token itself is a code follow-up.
+- **Subtle Ink** (`#6c6c6c`): tertiary text — years, subtitles, footer, time-axis labels. The lightest text tier, tuned to sit just above the AA floor (4.99:1 on paper, 5.25:1 on panel white).
 - **Paper** (`#faf9f7`): the warm off-white body surface. The room the timeline lives in.
 - **Panel White** (`#ffffff`): raised surfaces — header, slide-in panel, tooltip, footer.
 - **Border** (`#e0ddd8`): warm hairline dividers and control outlines, tuned to the paper, never gray-cold.
@@ -116,18 +116,18 @@ A warm-neutral paper base carries near-black text and a single reserved slate-bl
 
 ### Tertiary — Role Encoding
 
-Lifetime bars are colored by role. Hue is a _shortcut_, never the sole signal — the person panel always spells the role out in words.
+Lifetime bars are colored by role. Each hue is deep enough that the 11px white bar name clears AA (composer 6.1:1, player 6.3:1, both 7.3:1), and a monochrome **glyph** prefixes the name so role survives color-blindness.
 
-- **Composer Blue** (`#4a90d9`): role = composer.
-- **Player Orange** (`#e67e22`): role = player.
-- **Both Purple** (`#8e44ad`): role = both.
+- **Composer Blue** (`#2f6690`, glyph `✎`): role = composer.
+- **Player Ochre** (`#8a5314`, glyph `♪`): role = player.
+- **Both Plum** (`#7a3f88`, glyph `◆`): role = both.
 
 ### Tertiary — Connection Encoding
 
 Connection lines are distinguished by **line pattern first, color second**, so the relationship survives color-blindness.
 
-- **Relative Red** (`#e74c3c`): family ties — drawn solid.
-- **Teacher Blue** (`#3498db`): student/teacher links — drawn dashed (`6 3`).
+- **Relative Red** (`#c0392b`): family ties — drawn solid.
+- **Teacher Blue** (`#2980b9`): student/teacher links — drawn dashed (`6 3`).
 
 ### Tertiary — Era Bands
 
@@ -143,7 +143,9 @@ Semi-transparent bands (Material-50 tints at 30% opacity) sit behind the timelin
 
 **The Color-Is-Information Rule.** Every non-neutral hue encodes data (role, relationship, era). No hue is chosen for flavor. If a color can't name what it means, it doesn't belong.
 
-**The AA-Contrast Rule.** Every text/background pairing meets WCAG 2.1 AA — 4.5:1 for normal-size text, 3:1 for large (≥18px, or bold ≥14px). Values inherited from the current code that fall short are flagged as known deviations pending a code follow-up, not endorsed patterns. The first is Subtle Ink `#888888` used as small text (see above).
+**The Shape-Encodes-Role Rule.** Categorical meaning never rests on hue alone. Role carries a monochrome glyph (`✎` composer, `♪` player, `◆` both) alongside its color; connections carry a line pattern (solid vs dashed) alongside theirs. The legend teaches both channels.
+
+**The AA-Contrast Rule.** Every text/background pairing meets WCAG 2.1 AA — 4.5:1 for normal-size text, 3:1 for large (≥18px, or bold ≥14px), and 3:1 for meaningful non-text (axis lines). Role fills are deep enough that the white bar names clear AA; Subtle Ink is `#6c6c6c`; the time-axis line is `#8c8c8c`.
 
 ## 3. Typography
 
@@ -206,13 +208,12 @@ Controls are **refined and restrained** — precise, quiet, and deferential to t
 
 ### Lifetime Bar (signature component)
 
-- **Style:** an SVG `<rect>`, 4px radius, filled by role color, with the name in 11px white sans inset at the left.
-- **Contrast (known deviation):** 11px white on the composer (`#4a90d9`, 3.34:1) and player (`#e67e22`, 2.85:1) fills is below AA 4.5:1 — this mirrors the current code, not an endorsed pairing. An AA-safe treatment (darker role fills, or a text plate/outline behind the name) is owed here; because white fails composer/player while black fails the purple "both" fill (3.58:1), there is no single-color swap, so the remedy lands with the code follow-up.
+- **Style:** an SVG `<rect>`, 4px radius, filled by the deep role color, with a role glyph (`✎`/`♪`/`◆`) and the name in 11px white sans inset at the left. White text clears AA on all three fills.
 - **States:** default; **highlighted** = 2px `#333` stroke (selected/connected); **dimmed** = 0.3 opacity (de-emphasized when another person is selected). Cursor is a pointer throughout.
 
 ### Connection Line (signature component)
 
-- **Style:** an SVG bezier curve between two bars. **Relative** = solid red (`#e74c3c`); **student/teacher** = dashed blue (`#3498db`, dash `6 3`). Pattern carries the meaning; color reinforces it.
+- **Style:** an SVG bezier curve between two bars. **Relative** = solid red (`#c0392b`); **student/teacher** = dashed blue (`#2980b9`, dash `6 3`). Pattern carries the meaning; color reinforces it.
 
 ## 6. Do's and Don'ts
 
@@ -221,9 +222,9 @@ Controls are **refined and restrained** — precise, quiet, and deferential to t
 - **Do** reserve Cormorant Garamond for names and titles; set every control, label, datum, and body line in Karla.
 - **Do** hold the slate-blue accent (`#3d5a80`) to links and interactive affordances, under ~10% of any screen.
 - **Do** render era bands at 30% opacity behind the timeline as orientation only.
-- **Do** back every hue-coded signal with a non-color cue — the spelled-out role badge in the panel, and solid-vs-dashed connection lines — so meaning survives color-blindness.
+- **Do** back every hue-coded signal with a non-color cue — the per-bar role glyph (`✎`/`♪`/`◆`), solid-vs-dashed connection lines, and the spelled-out role in the panel — so meaning survives color-blindness.
 - **Do** honor `prefers-reduced-motion`: replace the 0.3s panel slide and hover transitions with an instant or crossfade alternative.
-- **Do** meet WCAG 2.1 AA contrast on text (4.5:1 normal, 3:1 large); the current Subtle-Ink small text is a flagged sub-AA deviation to remediate in code, not a pattern to copy.
+- **Do** keep every text pairing at WCAG 2.1 AA — Subtle Ink is `#6c6c6c`, the role fills are deep enough for white bar names, and the axis line meets the 3:1 non-text threshold.
 - **Do** keep surfaces flat; add shadow only to the floating panel and tooltip.
 
 ### Don't:
@@ -234,5 +235,5 @@ Controls are **refined and restrained** — precise, quiet, and deferential to t
 - **Don't** drift corporate or sterile — warmth is carried by the paper surface (`#faf9f7`) and serif names; never flatten to cold enterprise gray.
 - **Don't** set UI labels, controls, or data in the display serif, and never multiply the uppercase role label into per-section kickers.
 - **Don't** rely on hue alone to distinguish composer/player/both or relative/teacher connections.
-- **Don't** treat the 11px-white-on-role-fill bar labels as AA-compliant — white clears only the purple "both" fill; composer (3.34:1) and player (2.85:1) are sub-AA and owed a darker-fill or text-plate remedy in the code follow-up.
+- **Don't** lighten the role fills back toward the old bright Material hues — the deep values are what let the white bar names clear AA; brightening them breaks contrast.
 - **Don't** put shadow on a resting surface (bars, bands, chips, controls); a shadow at rest is a bug.

--- a/src/components/ConnectionLine.tsx
+++ b/src/components/ConnectionLine.tsx
@@ -1,9 +1,5 @@
 import type { ConnectionType } from '../types';
-
-const TYPE_STYLES: Record<ConnectionType, { color: string; dash?: string }> = {
-  relative: { color: '#E74C3C' },
-  'student-teacher': { color: '#3498DB', dash: '6 3' },
-};
+import { CONNECTION_STYLES } from '../theme';
 
 interface ConnectionLineProps {
   x1: number;
@@ -24,7 +20,7 @@ export function ConnectionLine({
   highlighted,
   dimmed,
 }: ConnectionLineProps) {
-  const style = TYPE_STYLES[type];
+  const style = CONNECTION_STYLES[type];
   const midX = (x1 + x2) / 2;
   const d = `M ${x1} ${y1} Q ${midX} ${y1} ${midX} ${(y1 + y2) / 2} Q ${midX} ${y2} ${x2} ${y2}`;
   return (

--- a/src/components/EraBackgrounds.tsx
+++ b/src/components/EraBackgrounds.tsx
@@ -1,4 +1,5 @@
 import type { Era } from '../types';
+import { ERA_LABEL } from '../theme';
 
 interface EraBackgroundsProps {
   eras: Era[];
@@ -31,7 +32,7 @@ export function EraBackgrounds({
               y={16}
               textAnchor="middle"
               fontSize={11}
-              fill="#666"
+              fill={ERA_LABEL}
               fontWeight={600}
             >
               {era.name}

--- a/src/components/Legend.tsx
+++ b/src/components/Legend.tsx
@@ -1,19 +1,54 @@
+import type { Role, ConnectionType } from '../types';
+import {
+  ROLE_COLORS,
+  ROLE_LABELS,
+  ROLE_GLYPHS,
+  CONNECTION_STYLES,
+  CONNECTION_LABELS,
+} from '../theme';
+
+const ROLES: Role[] = ['composer', 'player', 'both'];
+const CONNECTIONS: ConnectionType[] = ['relative', 'student-teacher'];
+
 export function Legend() {
   return (
     <div className="legend">
       <div className="legend-section">
-        <span className="legend-line legend-line--relative" />
-        <span>Relative</span>
-        <span className="legend-line legend-line--student-teacher" />
-        <span>Student/Teacher</span>
+        {CONNECTIONS.map((type) => (
+          <span key={type} className="legend-item">
+            <svg
+              className="legend-line"
+              width={24}
+              height={4}
+              aria-hidden="true"
+            >
+              <line
+                x1={0}
+                y1={2}
+                x2={24}
+                y2={2}
+                stroke={CONNECTION_STYLES[type].color}
+                strokeWidth={2}
+                strokeDasharray={CONNECTION_STYLES[type].dash}
+              />
+            </svg>
+            {CONNECTION_LABELS[type]}
+          </span>
+        ))}
       </div>
       <div className="legend-section">
-        <span className="legend-dot" style={{ backgroundColor: '#4A90D9' }} />
-        <span>Composer</span>
-        <span className="legend-dot" style={{ backgroundColor: '#E67E22' }} />
-        <span>Player</span>
-        <span className="legend-dot" style={{ backgroundColor: '#8E44AD' }} />
-        <span>Both</span>
+        {ROLES.map((role) => (
+          <span key={role} className="legend-item">
+            <span
+              className="legend-swatch"
+              style={{ backgroundColor: ROLE_COLORS[role] }}
+              aria-hidden="true"
+            >
+              {ROLE_GLYPHS[role]}
+            </span>
+            {ROLE_LABELS[role]}
+          </span>
+        ))}
       </div>
     </div>
   );

--- a/src/components/PersonBar.test.tsx
+++ b/src/components/PersonBar.test.tsx
@@ -59,7 +59,12 @@ test('displays person name', () => {
     </svg>,
   );
   const text = container.querySelector('text');
-  expect(text?.textContent).toBe('J.S. Bach');
+  expect(text?.textContent).toContain('J.S. Bach');
+});
+
+test('prefixes the name with the role glyph (non-color cue)', () => {
+  const group = renderBar();
+  expect(group.querySelector('text')?.textContent).toContain('✎');
 });
 
 test('calls onClick when clicked', () => {
@@ -117,7 +122,7 @@ test('exposes button semantics and an accessible label', () => {
   expect(group).toHaveAttribute('tabindex', '0');
   const label = group.getAttribute('aria-label') ?? '';
   expect(label).toContain('J.S. Bach');
-  expect(label).toContain('Composer');
+  expect(label).toContain('composer');
   expect(label).toContain('1685');
 });
 

--- a/src/components/PersonBar.tsx
+++ b/src/components/PersonBar.tsx
@@ -1,16 +1,12 @@
-import type { Person, Role } from '../types';
-
-const ROLE_COLORS: Record<Role, string> = {
-  composer: '#4A90D9',
-  player: '#E67E22',
-  both: '#8E44AD',
-};
-
-const ROLE_LABELS: Record<Role, string> = {
-  composer: 'Composer',
-  player: 'Player',
-  both: 'Composer and player',
-};
+import type { Person } from '../types';
+import {
+  ROLE_COLORS,
+  ROLE_ARIA,
+  ROLE_GLYPHS,
+  BAR_TEXT,
+  BAR_HIGHLIGHT_STROKE,
+  FOCUS_RING,
+} from '../theme';
 
 interface PersonBarProps {
   person: Person;
@@ -49,7 +45,7 @@ export function PersonBar({
     ? `${person.born} (estimated)`
     : `${person.born}`;
   const years = `${bornLabel} to ${person.died ?? 'present'}`;
-  const ariaLabel = `${person.fullName ?? person.name}, ${ROLE_LABELS[person.role]}, ${years}`;
+  const ariaLabel = `${person.fullName ?? person.name}, ${ROLE_ARIA[person.role]}, ${years}`;
 
   const handleKeyDown = (e: React.KeyboardEvent<SVGGElement>) => {
     if (e.key === 'Enter' || e.key === ' ') {
@@ -85,17 +81,17 @@ export function PersonBar({
         height={height}
         rx={4}
         fill={color}
-        stroke={highlighted ? '#333' : 'none'}
+        stroke={highlighted ? BAR_HIGHLIGHT_STROKE : 'none'}
         strokeWidth={strokeWidth}
       />
       <text
         x={x + 6}
         y={y + height / 2 + 4}
         fontSize={11}
-        fill="#fff"
+        fill={BAR_TEXT}
         fontWeight={500}
       >
-        {person.name}
+        {`${ROLE_GLYPHS[person.role]} ${person.name}`}
       </text>
       <rect
         className="person-bar__focus-ring"
@@ -105,7 +101,7 @@ export function PersonBar({
         height={height + 4}
         rx={6}
         fill="none"
-        stroke="#3d5a80"
+        stroke={FOCUS_RING}
         strokeWidth={2}
         pointerEvents="none"
       />

--- a/src/components/TimeAxis.tsx
+++ b/src/components/TimeAxis.tsx
@@ -1,3 +1,5 @@
+import { AXIS_LINE, AXIS_TEXT } from '../theme';
+
 interface TimeAxisProps {
   startYear: number;
   endYear: number;
@@ -24,7 +26,7 @@ export function TimeAxis({
         x2={yearToPixel(endYear)}
         y1={y}
         y2={y}
-        stroke="#ccc"
+        stroke={AXIS_LINE}
         strokeWidth={1}
       />
       {ticks.map((year) => {
@@ -36,7 +38,7 @@ export function TimeAxis({
               x2={x}
               y1={y}
               y2={y + 8}
-              stroke="#ccc"
+              stroke={AXIS_LINE}
               strokeWidth={1}
             />
             <text
@@ -44,7 +46,7 @@ export function TimeAxis({
               y={y + 22}
               textAnchor="middle"
               fontSize={12}
-              fill="#888"
+              fill={AXIS_TEXT}
             >
               {year}
             </text>

--- a/src/components/Tooltip.tsx
+++ b/src/components/Tooltip.tsx
@@ -1,10 +1,5 @@
-import type { Person, Role } from '../types';
-
-const ROLE_LABELS: Record<Role, string> = {
-  composer: 'Composer',
-  player: 'Player',
-  both: 'Composer & player',
-};
+import type { Person } from '../types';
+import { ROLE_LABELS, ROLE_GLYPHS } from '../theme';
 
 interface TooltipProps {
   person: Person | null;
@@ -31,7 +26,9 @@ export function Tooltip({ person, x, y }: TooltipProps) {
     >
       <strong>{person.fullName ?? person.name}</strong>
       <div className="tooltip__years">{years}</div>
-      <div className="tooltip__role">{ROLE_LABELS[person.role]}</div>
+      <div className="tooltip__role">
+        {ROLE_GLYPHS[person.role]} {ROLE_LABELS[person.role]}
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -12,7 +12,7 @@
   --font-body: 'Karla', 'Helvetica Neue', sans-serif;
   --color-ink: #1a1a1a;
   --color-ink-muted: #555;
-  --color-ink-subtle: #888;
+  --color-ink-subtle: #6c6c6c;
   --color-accent: #3d5a80;
   --color-border: #e0ddd8;
   --color-bg: #faf9f7;
@@ -205,34 +205,30 @@ select:focus-visible,
 .legend-section {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 16px;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 
 .legend-line {
   display: inline-block;
-  width: 24px;
-  height: 2px;
+  vertical-align: middle;
 }
 
-.legend-line--relative {
-  background: #e74c3c;
-}
-
-.legend-line--student-teacher {
-  background: repeating-linear-gradient(
-    90deg,
-    #3498db 0,
-    #3498db 6px,
-    transparent 6px,
-    transparent 10px
-  );
-}
-
-.legend-dot {
-  display: inline-block;
-  width: 10px;
-  height: 10px;
-  border-radius: 50%;
+.legend-swatch {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 14px;
+  border-radius: 3px;
+  color: #fff;
+  font-size: 10px;
+  line-height: 1;
 }
 
 /* Person panel */

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,0 +1,62 @@
+import type { Role, ConnectionType } from './types';
+
+// Single source of truth for the timeline's data-visualization colors and
+// encodings. SVG components can't read the CSS custom properties in index.css
+// cleanly, so these live here and are imported wherever a bar, line, axis, or
+// legend swatch is drawn — keeping the bars and their legend from drifting.
+
+/**
+ * Deep, muted role fills. White 11px bar text clears WCAG AA on all three
+ * (composer 6.1:1, player 6.3:1, both 7.3:1).
+ */
+export const ROLE_COLORS: Record<Role, string> = {
+  composer: '#2f6690',
+  player: '#8a5314',
+  both: '#7a3f88',
+};
+
+/** Concise visible role names (legend, tooltip). */
+export const ROLE_LABELS: Record<Role, string> = {
+  composer: 'Composer',
+  player: 'Player',
+  both: 'Both',
+};
+
+/** Fuller role wording for screen-reader accessible names. */
+export const ROLE_ARIA: Record<Role, string> = {
+  composer: 'composer',
+  player: 'player',
+  both: 'composer and player',
+};
+
+/**
+ * Non-color role cue (WCAG 1.4.1). A monochrome glyph carries the role
+ * independently of hue; the legend teaches the mapping.
+ */
+export const ROLE_GLYPHS: Record<Role, string> = {
+  composer: '✎',
+  player: '♪',
+  both: '◆',
+};
+
+/** Connection lines: pattern (solid vs dashed) carries meaning, color reinforces. */
+export const CONNECTION_STYLES: Record<
+  ConnectionType,
+  { color: string; dash?: string }
+> = {
+  relative: { color: '#c0392b' },
+  'student-teacher': { color: '#2980b9', dash: '6 3' },
+};
+
+export const CONNECTION_LABELS: Record<ConnectionType, string> = {
+  relative: 'Relative',
+  'student-teacher': 'Student/Teacher',
+};
+
+// Neutral viz grays (SVG-only; kept out of the CSS token layer).
+export const BAR_TEXT = '#ffffff';
+export const BAR_HIGHLIGHT_STROKE = '#333333';
+export const FOCUS_RING = '#3d5a80';
+export const AXIS_LINE = '#8c8c8c';
+export const AXIS_TEXT = '#6c6c6c';
+export const ERA_LABEL = '#666666';


### PR DESCRIPTION
Resolves the audit's deferred **color** items and the harden PR's deferred **WCAG 1.4.1** gap. Independent of the gender PR (#88).

## Contrast (WCAG AA)
- **Deepened role fills** — composer `#2f6690`, player `#8a5314`, both `#7a3f88` — so the white 11px bar names now clear AA on all three (~6–7:1), where the old bright Material hues failed (composer 3.34:1, player 2.85:1). Muted/editorial, fitting the "aged manuscript" identity.
- **Darkened `--color-ink-subtle`** `#888` → `#6c6c6c` (4.99:1 on paper / 5.25:1 on white) — fixes the sub-AA years / subtitles / footer / axis-label text app-wide.
- **Time-axis line** `#ccc` → `#8c8c8c` (3.2:1) and **connection lines** deepened (`#c0392b` / `#2980b9`) to clear the 3:1 non-text threshold.

## Colorblind-safe role encoding (WCAG 1.4.1)
- A monochrome **role glyph** now prefixes each bar name — **✎ composer, ♪ player, ◆ both** — so role reads without relying on hue. Mirrored in the tooltip and taught in the legend (glyph-on-color swatch). Connections already used solid-vs-dashed; role now has its own non-color channel too.

## Token consolidation (theming)
- New **`src/theme.ts`** is the single source for all data-viz colors, role labels, role glyphs, and connection styles. `PersonBar`, `Legend`, `ConnectionLine`, `TimeAxis`, `EraBackgrounds`, and `Tooltip` now import from it instead of hard-coding + duplicating hex across 6 files, so the bars and their legend can't drift.

## Docs
- `DESIGN.md` + `.impeccable/design.json` updated to the compliant palette; the now-resolved sub-AA "known deviation" flags are removed, and a **Shape-Encodes-Role** rule is added.

## Verification
`tsc`, ESLint, Prettier, `vite build`, and **79 tests** pass; coverage above thresholds (Stmts 88.4 / Branches 71.2 / Funcs 86.7 / Lines 90.6). All contrast ratios recomputed and confirmed. The one thing not verifiable here: the *visual* look of the deep palette + glyphs (no browser backend in this environment) — worth an eyeball via `npm run dev` before merge. The glyph set (✎/♪/◆) is trivially swappable in `src/theme.ts` if you'd prefer different marks.