### PR TITLE
Add Derek Bourgeois to trombone timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -2576,6 +2576,17 @@
     "websiteUrl": null
   },
   {
+    "id": "bourgeois",
+    "name": "D. Bourgeois",
+    "born": 1941,
+    "died": 2017,
+    "role": "composer",
+    "bio": "Extraordinarily prolific English composer of 116 symphonies and extensive brass and wind band repertoire, including a Trombone Concerto (1988) and a Concerto for Bass Trombone and Band (2006). He served as director of the National Youth Orchestra (1984-1993) and director of music at St Paul's Girls' School (1994-2002).",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Derek_Bourgeois",
+    "websiteUrl": null
+  },
+  {
     "id": "fred-wesley",
     "name": "F. Wesley",
     "born": 1943,

--- a/public/data/trombone.json
+++ b/public/data/trombone.json
@@ -75,6 +75,7 @@
     "roswell-rudd",
     "dempster",
     "watrous",
+    "bourgeois",
     "fred-wesley",
     "slokar",
     "steve-turre",


### PR DESCRIPTION
## Summary

- Add Derek Bourgeois (1941-2017), English composer known for 116 symphonies and extensive brass/wind band repertoire (Trombone Concerto, Concerto for Bass Trombone and Band), to `people.json`
- Add `bourgeois` to `trombone.json`'s `peopleIds`, positioned by birth year between Bill Watrous (1939) and Fred Wesley (1943)

No free Wikipedia portrait thumbnail is available for this person, so `photoUrl` is set to `null` (same precedent as `shaham`, `watrous`, `dempster`).

Fixes #92

## Test plan

- [x] `npx vitest run src/data-integrity.test.ts` — passing
- [x] `npm test` (78 tests) — all passing
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] `npm run format:check` — clean (aside from pre-existing unrelated `.claude/settings.local.json` warning)