### PR TITLE
Add Douglas Yeo to trombone timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -2664,6 +2664,17 @@
     "websiteUrl": null
   },
   {
+    "id": "yeo",
+    "name": "D. Yeo",
+    "born": 1955,
+    "died": null,
+    "role": "player",
+    "bio": "American bass trombonist who was principal bass trombone of the Boston Symphony Orchestra from 1985 to 2012, holding the John Moors Cabot Bass Trombone Chair. He is also a scholar of historical brass instruments and has taught at Arizona State University, Wheaton College, and the University of Illinois Urbana-Champaign.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Douglas_Yeo",
+    "websiteUrl": null
+  },
+  {
     "id": "nils-landgren",
     "name": "N. Landgren",
     "born": 1956,

--- a/public/data/trombone.json
+++ b/public/data/trombone.json
@@ -83,6 +83,7 @@
     "sandstrom",
     "ewazen",
     "eubanks",
+    "yeo",
     "nils-landgren",
     "lindberg",
     "alessi",


### PR DESCRIPTION
## Summary

- Adds Douglas Yeo (b. 1955), bass trombonist and Principal Bass Trombone of the Boston Symphony Orchestra (1985–2012), to `people.json` and `trombone.json`'s `peopleIds`, in birth-year order.
- No portrait was added: the Wikipedia article's `pageimages` API returns no thumbnail (the only image on the page is an action photo of Yeo demonstrating a historical buccin, not an infobox portrait), so `photoUrl` is set to `null` per existing precedent (e.g. `shaham`).

Fixes #93

## Test plan

- [x] `npx vitest run src/data-integrity.test.ts` — all passing
- [x] `npm test` (78 tests) — all passing
- [x] `npm run lint` — clean
- [x] `npm run build` — clean (typecheck + Vite build)