### PR TITLE
fix: responsive layout wrapping and timeline render memoization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright MCP scratch output
+.playwright-mcp/

--- a/src/components/ConnectionLine.tsx
+++ b/src/components/ConnectionLine.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { ConnectionType } from '../types';
 import { CONNECTION_STYLES } from '../theme';
 
@@ -11,7 +12,7 @@ interface ConnectionLineProps {
   dimmed: boolean;
 }
 
-export function ConnectionLine({
+export const ConnectionLine = memo(function ConnectionLine({
   x1,
   y1,
   x2,
@@ -33,4 +34,4 @@ export function ConnectionLine({
       opacity={dimmed ? 0.15 : highlighted ? 1 : 0.5}
     />
   );
-}
+});

--- a/src/components/EraBackgrounds.tsx
+++ b/src/components/EraBackgrounds.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { Era } from '../types';
 import { ERA_LABEL } from '../theme';
 
@@ -7,7 +8,7 @@ interface EraBackgroundsProps {
   height: number;
 }
 
-export function EraBackgrounds({
+export const EraBackgrounds = memo(function EraBackgrounds({
   eras,
   yearToPixel,
   height,
@@ -42,4 +43,4 @@ export function EraBackgrounds({
       })}
     </g>
   );
-}
+});

--- a/src/components/PersonBar.tsx
+++ b/src/components/PersonBar.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { Person } from '../types';
 import {
   ROLE_COLORS,
@@ -23,7 +24,7 @@ interface PersonBarProps {
   onBlur: () => void;
 }
 
-export function PersonBar({
+export const PersonBar = memo(function PersonBar({
   person,
   x,
   width,
@@ -107,4 +108,4 @@ export function PersonBar({
       />
     </g>
   );
-}
+});

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { memo, useRef, useEffect } from 'react';
 import type { InstrumentData, Person } from '../types';
 import { useTimelineScale } from '../hooks/useTimelineScale';
 import { TimelineSVG } from './TimelineSVG';
@@ -14,7 +14,7 @@ interface TimelineViewProps {
   onPersonBlur: () => void;
 }
 
-export function TimelineView({
+export const TimelineView = memo(function TimelineView({
   data,
   selectedPersonId,
   hoveredPersonId,
@@ -71,4 +71,4 @@ export function TimelineView({
       />
     </div>
   );
-}
+});

--- a/src/index.css
+++ b/src/index.css
@@ -97,8 +97,10 @@ select:focus-visible,
 /* Header */
 .header {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
+  gap: 10px 16px;
   padding: 20px 28px 16px;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-panel-bg);
@@ -112,8 +114,9 @@ select:focus-visible,
 
 .header__title-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 14px;
+  gap: 10px 14px;
 }
 
 .header__logo {
@@ -194,7 +197,8 @@ select:focus-visible,
 /* Legend */
 .legend {
   display: flex;
-  gap: 24px;
+  flex-wrap: wrap;
+  gap: 8px 24px;
   padding: 10px 28px;
   font-size: 0.78rem;
   font-weight: 500;
@@ -470,5 +474,55 @@ select:focus-visible,
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+}
+
+/* Narrow viewports: tighten chrome so the header and legend never force
+   the page to scroll horizontally (the timeline has its own scroll). */
+@media (max-width: 640px) {
+  .header {
+    padding: 14px 16px 12px;
+  }
+
+  .header__title {
+    font-size: 1.35rem;
+  }
+
+  .timeline-view {
+    padding: 12px 16px;
+  }
+
+  .legend {
+    padding: 10px 16px;
+  }
+
+  .footer {
+    padding: 12px 16px;
+  }
+}
+
+/* Touch input: meet the 44px minimum target size. */
+@media (pointer: coarse) {
+  .header__select {
+    min-height: 44px;
+  }
+
+  .header__links a,
+  .footer a {
+    padding: 8px 0;
+  }
+
+  .person-panel__conn-link {
+    padding: 6px 0;
+  }
+
+  .person-panel__close {
+    top: 8px;
+    right: 8px;
+    display: flex;
+    width: 44px;
+    height: 44px;
+    align-items: center;
+    justify-content: center;
   }
 }


### PR DESCRIPTION
The last two items from the `$impeccable audit`. **Stacked on #89 (colorize)** — its base is the colorize branch, so this diff shows only the adapt/optimize changes. Retarget to `main` (and I'll rebase) once #89 merges.

## adapt — responsive (the audit's Responsive dimension)
At 390px the page scrolled horizontally to 545px because the three header nav links didn't fit. Now:
- **Header and legend wrap** instead of overflowing; the page no longer scrolls horizontally on mobile (the timeline keeps its own horizontal scroll).
- A **≤640px breakpoint** tightens header/legend/footer padding and the title size.
- **`@media (pointer: coarse)`** raises the instrument select, nav/footer links, panel connection links, and the close button to **≥44px** touch targets — only on touch devices, so the desktop controls stay compact.

Verified in a real browser (Playwright): at 390px, body scroll-width 375 ≤ viewport, header/legend no longer overflow.

## optimize — re-renders (the audit's Performance dimension)
- **`memo(TimelineView)`** — the key fix: tooltip-position state updates (one per mousemove *while hovering*) no longer re-render the whole timeline subtree, since TimelineView's props are unchanged. (The per-frame `setState` itself was already guarded in the harden PR.)
- **`memo(PersonBar / ConnectionLine / EraBackgrounds)`** — unchanged bars, lines, and bands skip re-rendering.

## Verification
Playwright browser check (mobile overflow gone; deep palette + glyphs render correctly) plus `tsc`, ESLint, Prettier, **79 tests**, coverage above thresholds (Stmts 88.6 / Branches 71.2 / Funcs 86.7 / Lines 90.8), and `vite build`.

## Not included
The dead `useOrientation` hook / unimplemented portrait vertical-timeline is a **feature**, not a responsive-CSS fix — the horizontal-scroll timeline works on mobile — so it's left as an optional future `craft`. That's the only remaining audit thread.