### PR TITLE
Add Gordon Jacob to trombone timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -2649,6 +2649,18 @@
     "websiteUrl": null
   },
   {
+    "id": "jacob",
+    "name": "G. Jacob",
+    "born": 1895,
+    "died": 1984,
+    "role": "composer",
+    "gender": "male",
+    "bio": "English composer and teacher renowned for his substantial output of wind band and brass music, including a Trombone Concerto (1956) that remains part of the standard repertoire. He taught composition and orchestration at the Royal College of Music from 1926 to 1966, mentoring generations of British composers.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Gordon_Jacob",
+    "websiteUrl": null
+  },
+  {
     "id": "tomasi",
     "name": "H. Tomasi",
     "born": 1901,

--- a/public/data/trombone.json
+++ b/public/data/trombone.json
@@ -56,6 +56,7 @@
     "grondahl",
     "kid-ory",
     "hindemith",
+    "jacob",
     "tomasi",
     "glenn-miller",
     "teagarden",

--- a/scripts/download-portraits.mjs
+++ b/scripts/download-portraits.mjs
@@ -100,6 +100,7 @@ const WIKIPEDIA_TITLES = {
   'carreno': 'Teresa_Carreño',
   'sibelius': 'Jean_Sibelius',
   'szymanowski': 'Karol_Szymanowski',
+  'jacob': 'Gordon_Jacob',
 };
 
 const THUMB_SIZE = 400;


### PR DESCRIPTION
## Summary

- Add Gordon Jacob (1895–1984) as a composer to the trombone timeline, per the "New person" issue submission
- No free-use portrait is available (Wikipedia article has no lead image), so `photoUrl` is `null`, matching the existing `shaham` precedent

Fixes #114

## Test plan

- [x] `npm test` — 84 tests passing
- [x] `npx vitest run src/data-integrity.test.ts` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Confirmed via Wikipedia API that the article has no thumbnail image