### PR TITLE
fix: responsive layout wrapping and timeline render memoization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ coverage
 *.sw?
 
 .claude/settings.local.json
+
+# Playwright MCP scratch output
+.playwright-mcp/

--- a/src/components/ConnectionLine.tsx
+++ b/src/components/ConnectionLine.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { ConnectionType } from '../types';
 import { CONNECTION_STYLES } from '../theme';
 
@@ -11,7 +12,7 @@ interface ConnectionLineProps {
   dimmed: boolean;
 }
 
-export function ConnectionLine({
+export const ConnectionLine = memo(function ConnectionLine({
   x1,
   y1,
   x2,
@@ -33,4 +34,4 @@ export function ConnectionLine({
       opacity={dimmed ? 0.15 : highlighted ? 1 : 0.5}
     />
   );
-}
+});

--- a/src/components/EraBackgrounds.tsx
+++ b/src/components/EraBackgrounds.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { Era } from '../types';
 import { ERA_LABEL } from '../theme';
 
@@ -7,7 +8,7 @@ interface EraBackgroundsProps {
   height: number;
 }
 
-export function EraBackgrounds({
+export const EraBackgrounds = memo(function EraBackgrounds({
   eras,
   yearToPixel,
   height,
@@ -42,4 +43,4 @@ export function EraBackgrounds({
       })}
     </g>
   );
-}
+});

--- a/src/components/PersonBar.tsx
+++ b/src/components/PersonBar.tsx
@@ -1,3 +1,4 @@
+import { memo } from 'react';
 import type { Person } from '../types';
 import {
   ROLE_COLORS,
@@ -23,7 +24,7 @@ interface PersonBarProps {
   onBlur: () => void;
 }
 
-export function PersonBar({
+export const PersonBar = memo(function PersonBar({
   person,
   x,
   width,
@@ -107,4 +108,4 @@ export function PersonBar({
       />
     </g>
   );
-}
+});

--- a/src/components/TimelineView.tsx
+++ b/src/components/TimelineView.tsx
@@ -1,4 +1,4 @@
-import { useRef, useEffect } from 'react';
+import { memo, useRef, useEffect } from 'react';
 import type { InstrumentData, Person } from '../types';
 import { useTimelineScale } from '../hooks/useTimelineScale';
 import { TimelineSVG } from './TimelineSVG';
@@ -14,7 +14,7 @@ interface TimelineViewProps {
   onPersonBlur: () => void;
 }
 
-export function TimelineView({
+export const TimelineView = memo(function TimelineView({
   data,
   selectedPersonId,
   hoveredPersonId,
@@ -71,4 +71,4 @@ export function TimelineView({
       />
     </div>
   );
-}
+});

--- a/src/index.css
+++ b/src/index.css
@@ -97,8 +97,10 @@ select:focus-visible,
 /* Header */
 .header {
   display: flex;
+  flex-wrap: wrap;
   align-items: flex-start;
   justify-content: space-between;
+  gap: 10px 16px;
   padding: 20px 28px 16px;
   border-bottom: 1px solid var(--color-border);
   background: var(--color-panel-bg);
@@ -112,8 +114,9 @@ select:focus-visible,
 
 .header__title-row {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
-  gap: 14px;
+  gap: 10px 14px;
 }
 
 .header__logo {
@@ -194,7 +197,8 @@ select:focus-visible,
 /* Legend */
 .legend {
   display: flex;
-  gap: 24px;
+  flex-wrap: wrap;
+  gap: 8px 24px;
   padding: 10px 28px;
   font-size: 0.78rem;
   font-weight: 500;
@@ -483,5 +487,55 @@ select:focus-visible,
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;
     scroll-behavior: auto !important;
+  }
+}
+
+/* Narrow viewports: tighten chrome so the header and legend never force
+   the page to scroll horizontally (the timeline has its own scroll). */
+@media (max-width: 640px) {
+  .header {
+    padding: 14px 16px 12px;
+  }
+
+  .header__title {
+    font-size: 1.35rem;
+  }
+
+  .timeline-view {
+    padding: 12px 16px;
+  }
+
+  .legend {
+    padding: 10px 16px;
+  }
+
+  .footer {
+    padding: 12px 16px;
+  }
+}
+
+/* Touch input: meet the 44px minimum target size. */
+@media (pointer: coarse) {
+  .header__select {
+    min-height: 44px;
+  }
+
+  .header__links a,
+  .footer a {
+    padding: 8px 0;
+  }
+
+  .person-panel__conn-link {
+    padding: 6px 0;
+  }
+
+  .person-panel__close {
+    top: 8px;
+    right: 8px;
+    display: flex;
+    width: 44px;
+    height: 44px;
+    align-items: center;
+    justify-content: center;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -526,7 +526,9 @@ select:focus-visible,
   }
 
   .person-panel__conn-link {
-    padding: 6px 0;
+    display: flex;
+    min-height: 44px;
+    align-items: center;
   }
 
   .person-panel__close {


### PR DESCRIPTION
Brings the **adapt (responsive) + optimize (memoization)** work to `main`. These changes were merged in PR #118 — but that PR was mistakenly based on the `music-timeline/colorize` branch (a stacked PR), so it merged **into that branch instead of `main`**. Colorize (#89) had already merged to `main` earlier, so `main` never received these changes. This re-lands them cleanly off `main` (cherry-pick of the #118 commit; diff is only the adapt/optimize changes).

## adapt — responsive
- Header and legend now **wrap** instead of forcing the page to scroll horizontally (at 390px the three nav links overflowed to 545px). Playwright-verified: body scroll-width 375 ≤ 390 viewport, no overflow.
- A ≤640px breakpoint tightens header/legend/footer padding and the title size.
- `@media (pointer: coarse)` raises the instrument select, nav/footer links, panel connection links, and the close button to **≥44px** touch targets (touch devices only).

## optimize — re-renders
- `memo(TimelineView)` stops tooltip-position updates (per mousemove while hovering) from re-rendering the whole timeline subtree.
- `memo(PersonBar / ConnectionLine / EraBackgrounds)` so unchanged bars/lines/bands skip re-rendering.

## Verification
`tsc`, ESLint, Prettier, **84 tests**, coverage above thresholds (Stmts 88.9 / Branches 73.1 / Funcs 87.4 / Lines 91.1), and `vite build` — all green on top of current `main`.