### PR TITLE
build: pin eslint tsconfigRootDir and ignore .claude worktrees

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -7,7 +7,7 @@ import prettier from 'eslint-config-prettier/flat';
 import { defineConfig, globalIgnores } from 'eslint/config';
 
 export default defineConfig([
-  globalIgnores(['dist', 'coverage']),
+  globalIgnores(['dist', 'coverage', '.claude']),
   {
     files: ['**/*.{ts,tsx}'],
     extends: [
@@ -20,6 +20,12 @@ export default defineConfig([
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        // Pin the root explicitly: without this, typescript-eslint auto-detects
+        // and fails ("multiple candidate TSConfigRootDirs") when the repo has
+        // nested git worktrees under .claude/worktrees, each carrying a tsconfig.
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
   },
 ]);


### PR DESCRIPTION
Fixes local `npm run lint` breaking whenever the repo has **nested git worktrees** under `.claude/worktrees/` — the companion to the TypeScript-7 / typescript-eslint work.

## Symptom
With one or more worktrees present, ESLint reported (up to) 100+ of:
> Parsing error: No tsconfigRootDir was set, and multiple candidate TSConfigRootDirs are present

typescript-eslint auto-detects `tsconfigRootDir` and finds several candidates (the repo's tsconfig **plus** each worktree's). CI never hit this because it checks out a clean tree (one candidate), so `main` looked fine while every worktree-based local lint failed — which is the project's normal workflow.

## Fix (two parts)
- **`parserOptions.tsconfigRootDir: import.meta.dirname`** — pin the root to the repo instead of auto-detecting (this alone fixed the repo's own `src/`).
- **`.claude` added to `globalIgnores`** — stop ESLint from linting source *inside* the nested worktrees.

With both, `npm run lint` passes cleanly from the main checkout even with worktrees present. No effect on CI (already green) or on any linted rule — purely resolves the parser-root ambiguity.