### PR TITLE
Add Jan Koetsier to trombone timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -2745,6 +2745,18 @@
     "websiteUrl": null
   },
   {
+    "id": "koetsier",
+    "name": "J. Koetsier",
+    "born": 1911,
+    "died": 2006,
+    "role": "composer",
+    "gender": "male",
+    "bio": "Dutch conductor and composer who led the Bavarian Radio Symphony Orchestra and taught conducting at the Munich Hochschule. He wrote a substantial body of brass chamber and solo music, including a widely performed trombone concerto and numerous trombone quartets.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Jan_Koetsier",
+    "websiteUrl": null
+  },
+  {
     "id": "kai-winding",
     "name": "K. Winding",
     "born": 1922,

--- a/public/data/trombone.json
+++ b/public/data/trombone.json
@@ -64,6 +64,7 @@
     "bozza",
     "creston",
     "vic-dickenson",
+    "koetsier",
     "kai-winding",
     "jj-johnson",
     "berio",

--- a/scripts/download-portraits.mjs
+++ b/scripts/download-portraits.mjs
@@ -101,6 +101,7 @@ const WIKIPEDIA_TITLES = {
   'sibelius': 'Jean_Sibelius',
   'szymanowski': 'Karol_Szymanowski',
   'jacob': 'Gordon_Jacob',
+  'koetsier': 'Jan_Koetsier',
 };
 
 const THUMB_SIZE = 400;


### PR DESCRIPTION
## Summary

- Add Jan Koetsier (1911–2006) as a composer to the trombone timeline, per the "New person" issue submission
- No free-use portrait is available (Wikipedia article has no lead image), so `photoUrl` is `null`, matching the existing `jacob`/`shaham` precedent

Fixes #124

## Test plan

- [x] `npm test` — 84 tests passing
- [x] `npx vitest run src/data-integrity.test.ts` — clean
- [x] `npm run lint` — clean
- [x] `npm run build` — clean
- [x] Confirmed via Wikipedia API that the article has no thumbnail image