### PR TITLE
chore: generate Conventional Commits titles from Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,11 +4,22 @@ updates:
     directory: '/'
     schedule:
       interval: 'weekly'
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
   - package-ecosystem: 'npm'
     directory: '/video'
     schedule:
       interval: 'weekly'
+    commit-message:
+      prefix: 'fix'
+      prefix-development: 'chore'
+      include: 'scope'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'weekly'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'


### PR DESCRIPTION
## Summary
- Every open Dependabot PR fails the "Validate PR title" check (`lint-pr-title.yml`, enforcing Conventional Commits) because Dependabot's default titles (e.g. "Bump remotion from 4.0.496 to 4.0.499") never match that format.
- Configures `commit-message` in `.github/dependabot.yml` so future Dependabot PRs get compliant titles: `fix(deps): bump ...` for production dependencies, `chore(deps-dev): bump ...` for dev dependencies, `chore(github-actions): bump ...` for Actions updates.
- This only affects **new** Dependabot PRs (and ones recreated via `@dependabot recreate` after this merges) — it does not retroactively retitle the 7 currently open Dependabot PRs.

## Test plan
- [ ] Merge to `main`
- [ ] Comment `@dependabot recreate` on an open Dependabot PR (or wait for next scheduled run) and confirm the new title passes "Validate PR title"