### PR TITLE
feat(piano): add Thomas Tomkins to piano timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -2566,6 +2566,18 @@
     "websiteUrl": null
   },
   {
+    "id": "tomkins",
+    "name": "T. Tomkins",
+    "born": 1572,
+    "died": 1656,
+    "role": "both",
+    "gender": "male",
+    "bio": "Welsh-born composer and organist, a pupil of Byrd, who served Worcester Cathedral and the Chapel Royal. His keyboard fugues, variations, and dances, preserved in a manuscript he copied in his final years, rank among the finest of the English virginal school.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Thomas_Tomkins",
+    "websiteUrl": null
+  },
+  {
     "id": "schutz",
     "name": "H. Schütz",
     "born": 1585,

--- a/public/data/piano.json
+++ b/public/data/piano.json
@@ -36,6 +36,7 @@
     "byrd",
     "sweelinck",
     "bull",
+    "tomkins",
     "frescobaldi",
     "froberger",
     "louis-couperin",


### PR DESCRIPTION
Adds **Thomas Tomkins** (1572–1656) to the piano timeline.

> Welsh-born composer and organist, a pupil of Byrd, who served Worcester Cathedral and the Chapel Royal. His keyboard fugues, variations, and dances, preserved in a manuscript he copied in his final years, rank among the finest of the English virginal school.

- `people.json` + `piano.json` entries
- No freely licensed portrait exists; `photoUrl: null` (46 existing precedents)

Dates verified against Wikipedia, Wikidata, and [specialist source](https://www.britannica.com/biography/Thomas-Tomkins). Shortlist and bios independently reviewed before submission.