### PR TITLE
feat(piano): add Johann Krieger to piano timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -84,6 +84,18 @@
     "websiteUrl": null
   },
   {
+    "id": "krieger",
+    "name": "J. Krieger",
+    "born": 1651,
+    "died": 1735,
+    "role": "both",
+    "gender": "male",
+    "bio": "German composer and organist who directed church music in Zittau for over half a century. Mattheson ranked his fugues beside Handel's, and Handel studied his Anmuthige Clavier-Übung and took a copy to England.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Johann_Krieger",
+    "websiteUrl": null
+  },
+  {
     "id": "pachelbel",
     "name": "J. Pachelbel",
     "born": 1653,

--- a/public/data/piano.json
+++ b/public/data/piano.json
@@ -40,6 +40,7 @@
     "louis-couperin",
     "buxtehude",
     "pasquini",
+    "krieger",
     "pachelbel",
     "fischer",
     "purcell",


### PR DESCRIPTION
Adds **Johann Krieger** (1651–1735) to the piano timeline.

> German composer and organist who directed church music in Zittau for over half a century. Mattheson ranked his fugues beside Handel's, and Handel studied his Anmuthige Clavier-Übung and took a copy to England.

- `people.json` + `piano.json` entries
- No freely licensed portrait exists; `photoUrl: null` (46 existing precedents)

Dates verified against Wikipedia, Wikidata, and [specialist source](https://www.deutsche-biographie.de/gnd123540682.html#ndbcontent). Shortlist and bios independently reviewed before submission.