### PR TITLE
feat(piano): add Frederic Rzewski to piano timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -1983,6 +1983,18 @@
     "websiteUrl": null
   },
   {
+    "id": "rzewski",
+    "name": "F. Rzewski",
+    "born": 1938,
+    "died": 2021,
+    "role": "both",
+    "gender": "male",
+    "bio": "American composer-pianist whose hour-long variations The People United Will Never Be Defeated! are a monument of political art music. A virtuoso performer, he premiered works from Stockhausen to his own.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Frederic_Rzewski",
+    "websiteUrl": null
+  },
+  {
     "id": "argerich",
     "name": "M. Argerich",
     "born": 1941,

--- a/public/data/piano.json
+++ b/public/data/piano.json
@@ -211,6 +211,7 @@
     "ashkenazy",
     "kapustin",
     "silvestrov",
+    "rzewski",
     "argerich",
     "pollini",
     "freire",


### PR DESCRIPTION
Adds **Frederic Rzewski** (1938–2021) to the piano timeline.

> American composer-pianist whose hour-long variations The People United Will Never Be Defeated! are a monument of political art music. A virtuoso performer, he premiered works from Stockhausen to his own.

- `people.json` + `piano.json` entries
- No freely licensed portrait exists; `photoUrl: null` (46 existing precedents)

Dates verified against Wikipedia, Wikidata, and [specialist source](https://www.naxos.com/Bio/Person/Frederic_Rzewski/17767). Shortlist and bios independently reviewed before submission.