### PR TITLE
feat(piano): add Julius Eastman to piano timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -3591,6 +3591,18 @@
     "websiteUrl": null
   },
   {
+    "id": "eastman",
+    "name": "J. Eastman",
+    "born": 1940,
+    "died": 1990,
+    "role": "both",
+    "gender": "male",
+    "bio": "American composer, pianist, and vocalist whose fierce post-minimalist works for multiple pianos confront race, sexuality, and power. Nearly lost after his death, pieces like Gay Guerrilla have been triumphantly revived.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Julius_Eastman",
+    "websiteUrl": null
+  },
+  {
     "id": "bourgeois",
     "name": "D. Bourgeois",
     "born": 1941,

--- a/public/data/piano.json
+++ b/public/data/piano.json
@@ -212,6 +212,7 @@
     "kapustin",
     "silvestrov",
     "rzewski",
+    "eastman",
     "argerich",
     "pollini",
     "freire",


### PR DESCRIPTION
Adds **Julius Eastman** (1940–1990) to the piano timeline.

> American composer, pianist, and vocalist whose fierce post-minimalist works for multiple pianos confront race, sexuality, and power. Nearly lost after his death, pieces like Gay Guerrilla have been triumphantly revived.

- `people.json` + `piano.json` entries
- No freely licensed portrait exists; `photoUrl: null` (46 existing precedents)

Dates verified against Wikipedia, Wikidata, and [specialist source](https://www.newworldrecords.org/products/julius-eastman-unjust-malaise). Shortlist and bios independently reviewed before submission.