### PR TITLE
feat(piano): add Unsuk Chin to piano timeline

### DIFF
--- a/public/data/people.json
+++ b/public/data/people.json
@@ -1833,6 +1833,19 @@
     "websiteUrl": "https://stephenhough.com"
   },
   {
+    "id": "unsuk-chin",
+    "name": "U. Chin",
+    "fullName": "Unsuk Chin",
+    "born": 1961,
+    "died": null,
+    "role": "composer",
+    "gender": "female",
+    "bio": "South Korean composer based in Berlin, a pupil of Ligeti and a leading contemporary composer. Her six Piano Etudes extend the virtuoso tradition with glittering, unpredictable invention.",
+    "photoUrl": null,
+    "wikiUrl": "https://en.wikipedia.org/wiki/Unsuk_Chin",
+    "websiteUrl": null
+  },
+  {
     "id": "grimaud",
     "name": "H. Grimaud",
     "born": 1969,

--- a/public/data/piano.json
+++ b/public/data/piano.json
@@ -180,6 +180,7 @@
     "pogorelich",
     "hamelin",
     "hough",
+    "unsuk-chin",
     "grimaud",
     "kissin",
     "ades",


### PR DESCRIPTION
Adds **Unsuk Chin** (1961–present) to the piano timeline.

> South Korean composer based in Berlin, a pupil of Ligeti and a leading contemporary composer. Her six Piano Etudes extend the virtuoso tradition with glittering, unpredictable invention.

- `people.json` + `piano.json` entries
- No freely licensed portrait exists; `photoUrl: null` (46 existing precedents)

Dates verified against Wikipedia, Wikidata, and [specialist source](https://www.boosey.com/composer/Unsuk+Chin). Shortlist and bios independently reviewed before submission.