### PR TITLE
chore: add local commit-msg hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,22 @@
+#!/usr/bin/env sh
+# Validates the commit message subject against Conventional Commits
+# (https://www.conventionalcommits.org/). Enabled via:
+#   git config core.hooksPath .githooks
+set -eu
+
+msg_file="$1"
+first_line=$(head -n1 "$msg_file")
+
+case "$first_line" in
+  "Merge "*|"Revert "*|"fixup! "*|"squash! "*) exit 0 ;;
+esac
+
+pattern='^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\([a-zA-Z0-9_./-]+\))?!?: .+'
+
+if ! printf '%s\n' "$first_line" | grep -Eq "$pattern"; then
+  echo "commit-msg: subject does not follow Conventional Commits:" >&2
+  echo "  $first_line" >&2
+  echo "  expected: type(scope)?: description" >&2
+  echo "  types: build chore ci docs feat fix perf refactor revert style test" >&2
+  exit 1
+fi


### PR DESCRIPTION
Adds `.githooks/commit-msg`, a local hook that validates the **commit message subject** against [Conventional Commits](https://www.conventionalcommits.org/).

This complements what CI already checks on `main`:

- `lint-pr-title.yml` validates the **PR title** (which becomes the squash-merge subject).
- `commitlint.yml` lints commits in CI, i.e. after they have been pushed.
- This hook catches a malformed subject **before the commit is created**, so you never have to amend or rebase to fix it.

The hook skips `Merge`/`Revert`/`fixup!`/`squash!` subjects and accepts the standard type set: `build chore ci docs feat fix perf refactor revert style test`, with an optional scope and optional `!` for breaking changes.

### Activation (one-time, per clone)

Git does not use hooks from a tracked directory automatically, so after cloning run:

```sh
git config core.hooksPath .githooks
```

Without that, the hook is inert and nothing changes locally.
